### PR TITLE
Calculate moving average, if needed, early in the pipeline

### DIFF
--- a/AcornSat.Core/SimpleMovingAverage.cs
+++ b/AcornSat.Core/SimpleMovingAverage.cs
@@ -29,7 +29,31 @@ namespace AcornSat.Core
                 samples.Dequeue();
             }
 
-            return samples.Average();            
+            if (samples.Count > _windowSize * .25f)
+            {
+                return samples.Average();
+            }
+
+            return null;
+        }
+
+        public static List<DataRecord> Calculate(int windowSize, List<DataRecord> dataRecords)
+        {
+            var ma = new SimpleMovingAverage(windowSize);
+            var movingAverageValues = new List<float?>();
+            var values = dataRecords.Select(x => x.Value).ToList();
+            var returnDataRecords = new List<DataRecord>();
+
+            dataRecords.ForEach(x => returnDataRecords.Add(new DataRecord
+            {
+                Day = x.Day,
+                Month = x.Month,
+                Year = x.Year,
+                Label = x.Label,
+                Value = ma.AddSample(x.Value)
+            }));
+            returnDataRecords = returnDataRecords.SkipWhile(x => !x.Value.HasValue).ToList();
+            return returnDataRecords;
         }
 
         public static List<float?> Calculate(int windowSize, List<float?> values)

--- a/AcornSat.Visualiser/Pages/Index.razor
+++ b/AcornSat.Visualiser/Pages/Index.razor
@@ -1111,6 +1111,11 @@
 
     void BuildProcessedDataSetsForYearlyView(List<SeriesWithData> chartSeriesWithData, bool inclusiveStartYear = true)
     {
+        // If we're doing smoothing via the moving average, precalculate these data and add them to PreProcessedDataSets.
+        // We do this because the SimpleMovingAverage calculate function will remove some years from the start of the data set.
+        // It removes these years because it doesn't have a good enough average to present it to the user.
+        // Therefore, we need to calculate the smoothing before we calculate the start year - the basis for labelling the chart
+        // If we're not calculating a moving average, PreProcessedDataSets = SourceDataSets
         foreach (var cs in chartSeriesWithData)
         {
             if (cs.ChartSeries.Smoothing == SeriesSmoothingOptions.MovingAverage)

--- a/AcornSat.Visualiser/Pages/Index.razor
+++ b/AcornSat.Visualiser/Pages/Index.razor
@@ -1095,18 +1095,7 @@
             ? ChartType.Line
             : ChartType.Bar;
 
-        switch (chartSeries.ChartSeries.Smoothing)
-        {
-            case SeriesSmoothingOptions.None:
-                await chart.AddDataSet(
-                    GetChartDataset(label, values, dataSet.MeasurementDefinition.UnitOfMeasure, chartType, colour, absoluteValues, redPositive));
-                break;
-
-            case SeriesSmoothingOptions.MovingAverage:
-                await AddMovingAverage(chartSeries.ChartSeries.SmoothingWindow, label, values, dataSet.MeasurementDefinition.UnitOfMeasure, colour);
-
-                break;
-        }
+        await chart.AddDataSet(GetChartDataset(label, values, dataSet.MeasurementDefinition.UnitOfMeasure, chartType, colour, absoluteValues, redPositive));
     }
 
     ChartTrendlineData CreateTrendline(int datasetIndex, ChartColor colour)
@@ -1120,17 +1109,32 @@
             };
     }
 
-    async Task AddMovingAverage(int smoothingWindow, string label, List<float?> values, UnitOfMeasure unitOfMeasure, ChartColor colour)
-    {
-        var simpleMovingAverages = SimpleMovingAverage.Calculate(smoothingWindow, values);
-
-        await chart.AddDataSet(GetLineChartDataset(label, simpleMovingAverages, colour, unitOfMeasure));
-    }
-
     void BuildProcessedDataSetsForYearlyView(List<SeriesWithData> chartSeriesWithData, bool inclusiveStartYear = true)
     {
+        foreach (var cs in chartSeriesWithData)
+        {
+            if (cs.ChartSeries.Smoothing == SeriesSmoothingOptions.MovingAverage)
+            {
+                cs.PreProcessedDataSets = cs.SourceDataSets
+                        .Select(
+                            x =>
+                                new DataSet
+                                    {
+                                        Location = x.Location,
+                                        MeasurementDefinition = x.MeasurementDefinition,
+                                        DataRecords = SimpleMovingAverage.Calculate(cs.ChartSeries.SmoothingWindow, x.DataRecords)
+                                    }
+                        )
+                        .ToList();
+            }
+            else
+            {
+                cs.PreProcessedDataSets = cs.SourceDataSets;
+            }
+        }
+
         // Calculate first and last year which we have a data record for, across all data sets underpinning all chart series
-        var allDataSets = chartSeriesWithData.SelectMany(x => x.SourceDataSets);
+        var allDataSets = chartSeriesWithData.SelectMany(x => x.PreProcessedDataSets);
         var allDataRecords = allDataSets.SelectMany(x => x.DataRecords);
 
         var startYear = inclusiveStartYear 
@@ -1142,23 +1146,22 @@
         {
             // Create new datasets, same as the source, but with any gap years filled with null records
             cs.ProcessedDataSets =
-                cs.SourceDataSets
+                cs.PreProcessedDataSets
                 .Select(
                     x =>
                         new DataSet
                             {
                                 Location = x.Location,
                                 MeasurementDefinition = x.MeasurementDefinition,
-                                DataRecords =
-                                    Enumerable.Range(startYear, latestYearAcrossAllDataSets - startYear + 1)
-                                    .Select(
-                                        year =>
-                                            // If there's a record in the source dataset, use it
-                                            x.DataRecords.SingleOrDefault(z => z.Year == year)
-                                            // Otherwise, create a null record
-                                            ?? new DataRecord { Year = (short)year, Value = null }
-                                    )
-                                    .ToList()
+                                DataRecords = Enumerable.Range(startYear, latestYearAcrossAllDataSets - startYear + 1)
+                                                        .Select(
+                                                            year =>
+                                                                // If there's a record in the source dataset, use it
+                                                                x.DataRecords.SingleOrDefault(z => z.Year == year)
+                                                                // Otherwise, create a null record
+                                                                ?? new DataRecord { Year = (short)year, Value = null }
+                                                        )
+                                                        .ToList()
                             }
                 )
                 .ToList();

--- a/AcornSat.Visualiser/Pages/Index.razor
+++ b/AcornSat.Visualiser/Pages/Index.razor
@@ -1153,15 +1153,16 @@
                             {
                                 Location = x.Location,
                                 MeasurementDefinition = x.MeasurementDefinition,
-                                DataRecords = Enumerable.Range(startYear, latestYearAcrossAllDataSets - startYear + 1)
-                                                        .Select(
-                                                            year =>
-                                                                // If there's a record in the source dataset, use it
-                                                                x.DataRecords.SingleOrDefault(z => z.Year == year)
-                                                                // Otherwise, create a null record
-                                                                ?? new DataRecord { Year = (short)year, Value = null }
-                                                        )
-                                                        .ToList()
+                                DataRecords =
+                                    Enumerable.Range(startYear, latestYearAcrossAllDataSets - startYear + 1)
+                                    .Select(
+                                        year =>
+                                            // If there's a record in the source dataset, use it
+                                            x.DataRecords.SingleOrDefault(z => z.Year == year)
+                                            // Otherwise, create a null record
+                                            ?? new DataRecord { Year = (short)year, Value = null }
+                                    )
+                                    .ToList()
                             }
                 )
                 .ToList();

--- a/AcornSat.Visualiser/UiModel/SeriesWithData.cs
+++ b/AcornSat.Visualiser/UiModel/SeriesWithData.cs
@@ -4,6 +4,7 @@
     {
         public ChartSeriesDefinition ChartSeries { get; set; }
         public List<DataSet> SourceDataSets { get; set; }
+        public List<DataSet> PreProcessedDataSets { get; set; }
         public List<DataSet> ProcessedDataSets { get; set; }
     }
 }


### PR DESCRIPTION
Instead of doing the moving average right before adding to the graph, move it to really early in the data pipeline, before we've calculated the start years. This is because the moving average should strip out a few years at the start, before there is an average worth looking at.