### PR TITLE
Labelling on chart fixes and maybe a map load error fix

### DIFF
--- a/ClimateExplorer.Visualiser/Shared/MapContainer.razor
+++ b/ClimateExplorer.Visualiser/Shared/MapContainer.razor
@@ -54,7 +54,7 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (Locations != null)
+        if (Locations != null && map != null)
         {
             await EnsureMapMarkers();
         }
@@ -81,7 +81,7 @@
 
     public async Task EnsureMapMarkers()
     {
-        if (_mapMarkersCreated || map == null)
+        if (_mapMarkersCreated)
         {
             return;
         }

--- a/ClimateExplorer.Visualiser/Shared/MapContainer.razor
+++ b/ClimateExplorer.Visualiser/Shared/MapContainer.razor
@@ -81,7 +81,7 @@
 
     public async Task EnsureMapMarkers()
     {
-        if (_mapMarkersCreated)
+        if (_mapMarkersCreated || map == null)
         {
             return;
         }

--- a/ClimateExplorer.Visualiser/UiLogic/ChartLogic.cs
+++ b/ClimateExplorer.Visualiser/UiLogic/ChartLogic.cs
@@ -65,22 +65,6 @@ public static class ChartLogic
         return lineChartDataset;
     }
 
-    private static string GetYAxisId(SeriesTransformations seriesTransformations, UnitOfMeasure unitOfMeasure)
-    {
-        return seriesTransformations switch
-        {
-            SeriesTransformations.IsFrosty                      => "daysOfFrost",
-            SeriesTransformations.DayOfYearIfFrost              => "dayOfYear",
-            SeriesTransformations.EqualOrAbove35                => "daysEqualOrAbove35",
-            SeriesTransformations.EqualOrAbove1                 => "daysEqualOrAbove1",
-            SeriesTransformations.EqualOrAbove1AndLessThan10    => "daysEqualOrAbove1LessThan10",
-            SeriesTransformations.EqualOrAbove10                => "daysEqualOrAbove10",
-            SeriesTransformations.EqualOrAbove10AndLessThan25   => "daysEqualOrAbove10LessThan25",
-            SeriesTransformations.EqualOrAbove25                => "daysEqualOrAbove25",
-            _                                                   => unitOfMeasure.ToString().ToLowerFirstChar()
-        };
-    }
-
     public static BarChartDataset<float?> GetBarChartDataset(
         string label, 
         List<float?> values, 
@@ -247,5 +231,21 @@ public static class ChartLogic
         }
 
         return new Tuple<BinIdentifier, BinIdentifier>(startBin, endBin);
+    }
+
+    private static string GetYAxisId(SeriesTransformations seriesTransformations, UnitOfMeasure unitOfMeasure)
+    {
+        return seriesTransformations switch
+        {
+            SeriesTransformations.IsFrosty => "daysOfFrost",
+            SeriesTransformations.DayOfYearIfFrost => "dayOfYear",
+            SeriesTransformations.EqualOrAbove35 => "daysEqualOrAbove35",
+            SeriesTransformations.EqualOrAbove1 => "daysEqualOrAbove1",
+            SeriesTransformations.EqualOrAbove1AndLessThan10 => "daysEqualOrAbove1LessThan10",
+            SeriesTransformations.EqualOrAbove10 => "daysEqualOrAbove10",
+            SeriesTransformations.EqualOrAbove10AndLessThan25 => "daysEqualOrAbove10LessThan25",
+            SeriesTransformations.EqualOrAbove25 => "daysEqualOrAbove25",
+            _ => unitOfMeasure.ToString().ToLowerFirstChar()
+        };
     }
 }

--- a/ClimateExplorer.Visualiser/UiModel/ChartSeriesDefinition.cs
+++ b/ClimateExplorer.Visualiser/UiModel/ChartSeriesDefinition.cs
@@ -105,6 +105,16 @@ public class ChartSeriesDefinition
                 segments.Add("Transformation: " + GetFriendlySeriesTransformationLabel(SeriesTransformation));
             }
 
+            if (Aggregation != SeriesAggregationOptions.Mean)
+            {
+                segments.Add("Aggregation: " + Aggregation);
+            }
+
+            if (Value != SeriesValueOptions.Value)
+            {
+                segments.Add("Value: " + Value);
+            }
+
             // Smoothing only happens when the x-axis is linear
             if (BinGranularity.IsLinear())
             {
@@ -117,16 +127,6 @@ public class ChartSeriesDefinition
                         segments.Add("Trendline");
                         break;
                 }
-            }
-
-            if (Aggregation != SeriesAggregationOptions.Mean)
-            {
-                segments.Add("Aggregation: " + Aggregation);
-            }
-
-            if (Value != SeriesValueOptions.Value)
-            {
-                segments.Add("Value: " + Value);
             }
 
             return String.Join(" | ", segments);
@@ -223,6 +223,16 @@ public class ChartSeriesDefinition
             segments.Add(GetFriendlySeriesTransformationLabel(SeriesTransformation));
         }
 
+        if (Aggregation != SeriesAggregationOptions.Mean)
+        {
+            segments.Add(Aggregation.ToString());
+        }
+
+        if (Value != SeriesValueOptions.Value)
+        {
+            segments.Add("Value: " + Value);
+        }
+
         // Smoothing only happens when the x-axis is linear
         if (BinGranularity.IsLinear())
         {
@@ -243,16 +253,6 @@ public class ChartSeriesDefinition
                     segments.Add("Trendline");
                     break;
             }
-        }
-
-        if (Aggregation != SeriesAggregationOptions.Mean)
-        {
-            segments.Add("Aggregation: " + Aggregation);
-        }
-
-        if (Value != SeriesValueOptions.Value)
-        {
-            segments.Add("Value: " + Value);
         }
 
         if (uomLabel != null)


### PR DESCRIPTION
Map error is:

TypeError: Cannot read properties of null (reading 'addLayer')
    at i.addTo (https://unpkg.com/leaflet@1.7.1/dist/leaflet.js:5:63275)
    at https://www.climateexplorer.net/_framework/blazor.webassembly.js:1:3332
    at new Promise (<anonymous>)
    at Object.beginInvokeJSFromDotNet (https://www.climateexplorer.net/_framework/blazor.webassembly.js:1:3306)
    at Object.St [as invokeJSFromDotNet] (https://www.climateexplorer.net/_framework/blazor.webassembly.js:1:59938)
    at _mono_wasm_invoke_js_blazor (https://www.climateexplorer.net/_framework/dotnet.6.0.8.o04gyxc4n3.js:1:173403)
    at wasm://wasm/008e4dc2:wasm-function[158]:0x163d4
    at wasm://wasm/008e4dc2:wasm-function[106]:0x70dc
    at wasm://wasm/008e4dc2:wasm-function[105]:0x5ff5
    at wasm://wasm/008e4dc2:wasm-function[7268]:0x180394
   at Microsoft.JSInterop.JSRuntime.<InvokeAsync>d__16`1[[Microsoft.JSInterop.IJSObjectReference, Microsoft.JSInterop, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].MoveNext()
   at DPBlazorMapLibrary.Layer.AddTo(Map map)
   at DPBlazorMapLibrary.LayerFactory.CreateMarkerAndAddToMap(LatLng latLng, Map map, MarkerOptions options)
   at ClimateExplorer.Visualiser.Shared.MapContainer.EnsureMapMarkers()
   at ClimateExplorer.Visualiser.Shared.MapContainer.OnParametersSetAsync()
   at Microsoft.AspNetCore.Components.ComponentBase.CallStateHasChangedOnAsyncCompletion(Task task)
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task , ComponentState )