### PR TITLE
Add MinimumDataResolution check

### DIFF
--- a/ClimateExplorer.Core/DataPreparation/DataSetBuilder.cs
+++ b/ClimateExplorer.Core/DataPreparation/DataSetBuilder.cs
@@ -18,6 +18,11 @@ public class DataSetBuilder
 
         Console.WriteLine("GetSeriesDataPointsForRequest completed in " + sw.Elapsed);
 
+        if (request.MinimumDataResolution != null && series.DataResolution < request.MinimumDataResolution)
+        {
+            throw new Exception($"The data resolution of this series is {series.DataResolution}. A minimum data resolution thresold of {request.MinimumDataResolution} is required for this type of aggregation.");
+        }
+
         // Run the rest of the pipeline (this is a separate method for testability)
         var dataPoints = BuildDataSetFromDataPoints(series.DataPoints!, series.DataResolution, request);
 

--- a/ClimateExplorer.Core/DataPreparation/Model/PostDataSetsRequestBody.cs
+++ b/ClimateExplorer.Core/DataPreparation/Model/PostDataSetsRequestBody.cs
@@ -1,5 +1,7 @@
 ﻿namespace ClimateExplorer.Core.DataPreparation;
 
+using static ClimateExplorer.Core.Enums;
+
 public class PostDataSetsRequestBody
 {
     public SeriesDerivationTypes SeriesDerivationType { get; set; }
@@ -26,4 +28,6 @@ public class PostDataSetsRequestBody
     public bool Anomaly { get; set; }
 
     public bool IncludeRawDataPoints { get; set; }
+
+    public DataResolution? MinimumDataResolution { get; set; }
 }

--- a/ClimateExplorer.Web.Client/Pages/Index.razor.cs
+++ b/ClimateExplorer.Web.Client/Pages/Index.razor.cs
@@ -444,6 +444,7 @@ public partial class Index : ChartablePage
                                 Year = csd.Year,
                                 SeriesTransformation = csd.SeriesTransformation,
                                 GroupingThreshold = csd.GroupingThreshold,
+                                MinimumDataResolution = csd.MinimumDataResolution,
                             });
                     }
                 }

--- a/ClimateExplorer.Web.Client/Services/DataService.cs
+++ b/ClimateExplorer.Web.Client/Services/DataService.cs
@@ -83,7 +83,8 @@ public class DataService : IDataService
         float requiredCupDataProportion,
         int cupSize,
         SeriesTransformations seriesTransformation,
-        short? year)
+        short? year,
+        DataResolution? minimumDataResolution)
     {
         var response =
             await httpClient.PostAsJsonAsync<PostDataSetsRequestBody>(
@@ -103,6 +104,7 @@ public class DataService : IDataService
                     SeriesTransformation = seriesTransformation,
                     Anomaly = seriesValueOption == SeriesValueOptions.Anomaly,
                     FilterToYear = year,
+                    MinimumDataResolution = minimumDataResolution,
                 });
 
         if (!response.IsSuccessStatusCode)

--- a/ClimateExplorer.Web.Client/Services/IDataService.cs
+++ b/ClimateExplorer.Web.Client/Services/IDataService.cs
@@ -25,7 +25,8 @@ public interface IDataService
         float requiredCupDataProportion,
         int cupSize,
         SeriesTransformations seriesTransformation,
-        short? year = null);
+        short? year = null,
+        DataResolution? minimumDataResolution = null);
     Task<IEnumerable<DataSet>> GetAggregateDataSet(DataType dataType, DataResolution resolution, DataAdjustment dataAdjustment, float? minLatitude, float? maxLatitude, short dayGrouping = 14, float dayGroupingThreshold = .7f, float regionThreshold = .7f);
     Task<Dictionary<string, string>> GetCountries();
 

--- a/ClimateExplorer.Web.Client/Shared/ChartSeriesListView.razor
+++ b/ClimateExplorer.Web.Client/Shared/ChartSeriesListView.razor
@@ -73,7 +73,8 @@ async Task OnDuplicateSeries(ChartSeriesDefinition csd)
             Value = csd.Value,
             Year = csd.Year,
             SeriesTransformation = csd.SeriesTransformation,
-            GroupingThreshold = csd.GroupingThreshold
+            GroupingThreshold = csd.GroupingThreshold,
+            MinimumDataResolution = csd.MinimumDataResolution,
         }
     );
 

--- a/ClimateExplorer.Web.Client/Shared/ChartView.razor.cs
+++ b/ClimateExplorer.Web.Client/Shared/ChartView.razor.cs
@@ -204,7 +204,8 @@ public partial class ChartView
                     GetGroupingThreshold(csd.GroupingThreshold),
                     SelectedDayGrouping,
                     csd.SeriesTransformation,
-                    csd.Year);
+                    csd.Year,
+                    csd.MinimumDataResolution);
 
             datasetsToReturn.Add(
                 new SeriesWithData() { ChartSeries = csd, SourceDataSet = dataSet });
@@ -596,6 +597,7 @@ public partial class ChartView
                         Year = year,
                         SeriesTransformation = csd.SeriesTransformation,
                         GroupingThreshold = csd.GroupingThreshold,
+                        MinimumDataResolution = csd.MinimumDataResolution,
                     });
             }
         }

--- a/ClimateExplorer.Web.Client/Shared/SuggestedCharts.razor
+++ b/ClimateExplorer.Web.Client/Shared/SuggestedCharts.razor
@@ -123,6 +123,12 @@
 
                     p.MissingChartSeries = true;
                 }
+                else if (csd.MinimumDataResolution != null && csd.SourceSeriesSpecifications!.Any(x => x.MeasurementDefinition!.DataResolution < csd.MinimumDataResolution))
+                {
+                    p.ChartSeriesList.Remove(csd);
+
+                    p.MissingChartSeries = true;
+                }
             }
 
             if (p.Variants != null)
@@ -134,6 +140,12 @@
                     foreach (var csd in v.ChartSeriesList!.ToArray())
                     {
                         if (!csd.SourceSeriesSpecifications!.Any() || csd.SourceSeriesSpecifications!.Any(x => x.MeasurementDefinition == null))
+                        {
+                            v.ChartSeriesList.Remove(csd);
+
+                            v.MissingChartSeries = true;
+                        }
+                        else if (csd.MinimumDataResolution != null && csd.SourceSeriesSpecifications!.Any(x => x.MeasurementDefinition!.DataResolution < csd.MinimumDataResolution))
                         {
                             v.ChartSeriesList.Remove(csd);
 

--- a/ClimateExplorer.Web.Client/UiLogic/ChartSeriesListSerializer.cs
+++ b/ClimateExplorer.Web.Client/UiLogic/ChartSeriesListSerializer.cs
@@ -105,6 +105,7 @@ public static class ChartSeriesListSerializer
                 SeriesTransformation = ParseEnum<SeriesTransformations>(segments[14]),
                 GroupingThreshold = ParseNullableFloat(segments[15]),
                 DataAvailable = bool.Parse(segments[16]),
+                MinimumDataResolution = (DataResolution?)ParseNullableEnum<DataResolution>(segments[17]),
             };
     }
 
@@ -241,6 +242,7 @@ public static class ChartSeriesListSerializer
                 csd.IsExpanded,
                 csd.SeriesTransformation,
                 csd.GroupingThreshold,
-                csd.DataAvailable);
+                csd.DataAvailable,
+                csd.MinimumDataResolution);
     }
 }

--- a/ClimateExplorer.Web.Client/UiModel/ChartSeriesDefinition.cs
+++ b/ClimateExplorer.Web.Client/UiModel/ChartSeriesDefinition.cs
@@ -48,6 +48,7 @@ public class ChartSeriesDefinition
     // Transient view state
     public bool IsExpanded { get; set; }
     public bool DataAvailable { get; internal set; } = true;
+    public DataResolution? MinimumDataResolution { get; set; }
 
     [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1009:Closing parenthesis should be spaced correctly", Justification = "Rule conflict")]
     public string FriendlyTitle

--- a/ClimateExplorer.Web.Client/UiModel/SuggestedPresetLists.cs
+++ b/ClimateExplorer.Web.Client/UiModel/SuggestedPresetLists.cs
@@ -53,7 +53,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                     },
                     new ChartSeriesDefinition()
                     {
@@ -64,9 +63,7 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
-                    }
-
+                    },
                 ],
                 Variants = [
                     new SuggestedChartPresetModelWithVariants()
@@ -84,7 +81,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 SeriesTransformation = SeriesTransformations.EqualOrAbove1,
                                 RequestedColour = UiLogic.Colours.Blue,
@@ -98,7 +94,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 SeriesTransformation = SeriesTransformations.EqualOrAbove10,
                                 RequestedColour = UiLogic.Colours.Pink,
@@ -122,7 +117,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 3,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 SeriesTransformation = SeriesTransformations.Identity,
                                 RequestedColour = UiLogic.Colours.Green,
@@ -136,7 +130,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 3,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Bar,
                                 SeriesTransformation = SeriesTransformations.Identity,
                             },
@@ -161,7 +154,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 10,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                     },
                     new ChartSeriesDefinition()
                     {
@@ -172,7 +164,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 5,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         RequestedColour = UiLogic.Colours.Black,
                     }
 
@@ -194,7 +185,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 10,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                             },
                             new ChartSeriesDefinition()
                             {
@@ -205,7 +195,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 RequestedColour = UiLogic.Colours.Yellow,
                                 GroupingThreshold = 0.1f,
                             }
@@ -227,7 +216,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                             },
                             new ChartSeriesDefinition()
                             {
@@ -238,7 +226,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 RequestedColour = UiLogic.Colours.Yellow,
                                 GroupingThreshold = 0.1f,
                             }
@@ -264,7 +251,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 5,
                         Value = SeriesValueOptions.Anomaly,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Bar,
                     },
                 ],
@@ -286,9 +272,7 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.None,
                                     SmoothingWindow = 5,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
-                                }
-
+                                },
                             ],
                     },
                     new SuggestedChartPresetModelWithVariants()
@@ -307,7 +291,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                             },
                             new ChartSeriesDefinition()
                             {
@@ -319,9 +302,7 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
-                            }
-
+                            },
                         ],
                     },
                 ],
@@ -343,7 +324,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Line,
                         SeriesTransformation = SeriesTransformations.EqualOrAbove35,
                     },
@@ -356,7 +336,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Line,
                         SeriesTransformation = SeriesTransformations.IsFrosty,
                     },
@@ -378,7 +357,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 SeriesTransformation = SeriesTransformations.DayOfYearIfFrost,
                             },
@@ -391,7 +369,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 SeriesTransformation = SeriesTransformations.DayOfYearIfFrost,
                             },
@@ -436,7 +413,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                     },
                     new ChartSeriesDefinition()
                     {
@@ -447,7 +423,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                     }
 
                 ],
@@ -469,7 +444,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 10,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                     },
                     new ChartSeriesDefinition()
                     {
@@ -480,7 +454,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 5,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         RequestedColour = UiLogic.Colours.Black,
                     }
 
@@ -503,7 +476,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 5,
                         Value = SeriesValueOptions.Anomaly,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Bar,
                     },
                 ],
@@ -526,7 +498,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 5,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                     },
                     new ChartSeriesDefinition()
                     {
@@ -538,7 +509,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 5,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                     },
                 ],
             });
@@ -579,7 +549,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                     },
                     new ChartSeriesDefinition()
                     {
@@ -590,7 +559,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                     }
 
                 ],
@@ -611,7 +579,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 10,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                             },
                             new ChartSeriesDefinition()
                             {
@@ -622,7 +589,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 RequestedColour = UiLogic.Colours.Black,
                             }
 
@@ -643,7 +609,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Anomaly,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Bar,
                             },
                         ],
@@ -664,7 +629,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                             },
                             new ChartSeriesDefinition()
                             {
@@ -676,7 +640,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                             },
                         ],
                     },
@@ -757,7 +720,6 @@ public static class SuggestedPresetLists
                             Smoothing = SeriesSmoothingOptions.MovingAverage,
                             SmoothingWindow = 10,
                             Value = SeriesValueOptions.Value,
-                            Year = null,
                             DisplayStyle = SeriesDisplayStyle.Line,
                             RequestedColour = UiLogic.Colours.Brown,
                         },
@@ -780,7 +742,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Brown,
                             },
@@ -793,7 +754,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Black,
                             },
@@ -815,7 +775,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.None,
                                     SmoothingWindow = 5,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                     RequestedColour = UiLogic.Colours.Brown,
                                 },
@@ -836,7 +795,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.None,
                                     SmoothingWindow = 5,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                     RequestedColour = UiLogic.Colours.Brown,
                                 },
@@ -857,7 +815,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.None,
                                     SmoothingWindow = 5,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                     RequestedColour = UiLogic.Colours.Brown,
                                 }
@@ -880,7 +837,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 5,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Green,
                                 GroupingThreshold = 0.1f,
@@ -894,7 +850,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.None,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Black,
                                 GroupingThreshold = 0.1f,
@@ -920,7 +875,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Bar,
                         RequestedColour = UiLogic.Colours.Red,
                     },
@@ -941,7 +895,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Green,
                             },
@@ -954,7 +907,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Blue,
                             },
@@ -975,7 +927,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.MovingAverage,
                                     SmoothingWindow = 20,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                     RequestedColour = UiLogic.Colours.Orange,
                                 },
@@ -988,7 +939,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.MovingAverage,
                                     SmoothingWindow = 20,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                     RequestedColour = UiLogic.Colours.Purple,
                                 },
@@ -1009,7 +959,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.MovingAverage,
                                     SmoothingWindow = 20,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                 },
                                 new ChartSeriesDefinition()
@@ -1021,7 +970,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.MovingAverage,
                                     SmoothingWindow = 20,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                 },
                             ],
@@ -1045,7 +993,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Bar,
                     },
                 ],
@@ -1065,7 +1012,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Green,
                             },
@@ -1078,7 +1024,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Blue,
                             },
@@ -1099,7 +1044,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Orange,
                             },
@@ -1112,7 +1056,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Purple,
                             },
@@ -1133,7 +1076,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                             },
                             new ChartSeriesDefinition()
@@ -1145,7 +1087,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                             },
                         ],
@@ -1165,7 +1106,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.MovingAverage,
                                     SmoothingWindow = 20,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                     RequestedColour = UiLogic.Colours.Blue,
                                     GroupingThreshold = 0.1f,
@@ -1179,7 +1119,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.MovingAverage,
                                     SmoothingWindow = 20,
                                     Value = SeriesValueOptions.Value,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                     RequestedColour = UiLogic.Colours.Orange,
                                     GroupingThreshold = 0.1f,
@@ -1201,7 +1140,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 20,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Pink,
                                 GroupingThreshold = 0.1f,
@@ -1227,7 +1165,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 10,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Line,
                         RequestedColour = UiLogic.Colours.Orange,
                         GroupingThreshold = 0.1f,
@@ -1241,7 +1178,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.MovingAverage,
                         SmoothingWindow = 10,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Line,
                         RequestedColour = UiLogic.Colours.Purple,
                         GroupingThreshold = 0.1f,
@@ -1264,7 +1200,6 @@ public static class SuggestedPresetLists
                                 Smoothing = SeriesSmoothingOptions.MovingAverage,
                                 SmoothingWindow = 10,
                                 Value = SeriesValueOptions.Value,
-                                Year = null,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 RequestedColour = UiLogic.Colours.Blue,
                                 GroupingThreshold = 0.1f,
@@ -1290,7 +1225,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 20,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Line,
                         RequestedColour = UiLogic.Colours.Grey,
                         GroupingThreshold = 0.05f,
@@ -1315,7 +1249,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 10,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Line,
                         RequestedColour = UiLogic.Colours.Green,
                         GroupingThreshold = 0.1f,
@@ -1329,7 +1262,6 @@ public static class SuggestedPresetLists
                         Smoothing = SeriesSmoothingOptions.None,
                         SmoothingWindow = 10,
                         Value = SeriesValueOptions.Value,
-                        Year = null,
                         DisplayStyle = SeriesDisplayStyle.Line,
                         RequestedColour = UiLogic.Colours.Orange,
                         GroupingThreshold = 0.1f,
@@ -1354,7 +1286,6 @@ public static class SuggestedPresetLists
                             Smoothing = SeriesSmoothingOptions.MovingAverage,
                             SmoothingWindow = 20,
                             Value = SeriesValueOptions.Anomaly,
-                            Year = null,
                             DisplayStyle = SeriesDisplayStyle.Line,
                         },
                         new ChartSeriesDefinition()
@@ -1366,7 +1297,6 @@ public static class SuggestedPresetLists
                             Smoothing = SeriesSmoothingOptions.MovingAverage,
                             SmoothingWindow = 20,
                             Value = SeriesValueOptions.Anomaly,
-                            Year = null,
                             DisplayStyle = SeriesDisplayStyle.Line,
                         },
                     ],
@@ -1387,7 +1317,6 @@ public static class SuggestedPresetLists
                                         Smoothing = SeriesSmoothingOptions.None,
                                         SmoothingWindow = 20,
                                         Value = SeriesValueOptions.Anomaly,
-                                        Year = null,
                                         DisplayStyle = SeriesDisplayStyle.Bar,
                                     },
                                 ],
@@ -1407,7 +1336,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.None,
                                     SmoothingWindow = 20,
                                     Value = SeriesValueOptions.Anomaly,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                 },
                                 new ChartSeriesDefinition()
@@ -1419,7 +1347,6 @@ public static class SuggestedPresetLists
                                     Smoothing = SeriesSmoothingOptions.None,
                                     SmoothingWindow = 20,
                                     Value = SeriesValueOptions.Anomaly,
-                                    Year = null,
                                     DisplayStyle = SeriesDisplayStyle.Line,
                                 },
                             ],

--- a/ClimateExplorer.Web.Client/UiModel/SuggestedPresetLists.cs
+++ b/ClimateExplorer.Web.Client/UiModel/SuggestedPresetLists.cs
@@ -84,6 +84,7 @@ public static class SuggestedPresetLists
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 SeriesTransformation = SeriesTransformations.EqualOrAbove1,
                                 RequestedColour = UiLogic.Colours.Blue,
+                                MinimumDataResolution = DataResolution.Daily,
                             },
                             new ChartSeriesDefinition()
                             {
@@ -97,6 +98,7 @@ public static class SuggestedPresetLists
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 SeriesTransformation = SeriesTransformations.EqualOrAbove10,
                                 RequestedColour = UiLogic.Colours.Pink,
+                                MinimumDataResolution = DataResolution.Daily,
                             }
 
                         ],
@@ -326,6 +328,7 @@ public static class SuggestedPresetLists
                         Value = SeriesValueOptions.Value,
                         DisplayStyle = SeriesDisplayStyle.Line,
                         SeriesTransformation = SeriesTransformations.EqualOrAbove35,
+                        MinimumDataResolution = DataResolution.Daily,
                     },
                     new ChartSeriesDefinition()
                     {
@@ -338,6 +341,7 @@ public static class SuggestedPresetLists
                         Value = SeriesValueOptions.Value,
                         DisplayStyle = SeriesDisplayStyle.Line,
                         SeriesTransformation = SeriesTransformations.IsFrosty,
+                        MinimumDataResolution = DataResolution.Daily,
                     },
                 ],
                 Variants =
@@ -359,6 +363,7 @@ public static class SuggestedPresetLists
                                 Value = SeriesValueOptions.Value,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 SeriesTransformation = SeriesTransformations.DayOfYearIfFrost,
+                                MinimumDataResolution = DataResolution.Daily,
                             },
                             new ChartSeriesDefinition()
                             {
@@ -371,6 +376,7 @@ public static class SuggestedPresetLists
                                 Value = SeriesValueOptions.Value,
                                 DisplayStyle = SeriesDisplayStyle.Line,
                                 SeriesTransformation = SeriesTransformations.DayOfYearIfFrost,
+                                MinimumDataResolution = DataResolution.Daily,
                             },
                         ],
                     },

--- a/ClimateExplorer.WebApi/Program.cs
+++ b/ClimateExplorer.WebApi/Program.cs
@@ -360,6 +360,7 @@ static PostDataSetsRequestBody GetPostRequestBody(PostDataSetsRequestBody body, 
         SeriesTransformation = body.SeriesTransformation,
         Anomaly = body.Anomaly,
         FilterToYear = body.FilterToYear,
+        MinimumDataResolution = body.MinimumDataResolution,
     };
 }
 


### PR DESCRIPTION
The MinimumDataResolution parameter ensures calculations on that only work when we have daily data are not attempted if we have weekly, monthly or other courser data resolution.

This was allowing incorrect "Days of rain" presets to run for all GHCNm locations.

Closes #411