### PR TITLE
DualRangeSlider component now works on Firefox

### DIFF
--- a/ClimateExplorer.Web.Client/Shared/DualRangeSlider.razor
+++ b/ClimateExplorer.Web.Client/Shared/DualRangeSlider.razor
@@ -12,6 +12,10 @@
         #myRangeSlider::-webkit-slider-thumb {
             width: @RangeWidth;
         }
+
+        #myRangeSlider::-moz-range-thumb {
+            width: @RangeWidth;
+        }
     </style>
     <div class="form_control">
         <span>@Min</span>

--- a/ClimateExplorer.Web.Client/Shared/DualRangeSlider.razor.css
+++ b/ClimateExplorer.Web.Client/Shared/DualRangeSlider.razor.css
@@ -67,7 +67,16 @@
         background: #f7f7f7;
     }
 
+    .extents-slider::-moz-range-thumb:hover {
+        background: #f7f7f7;
+    }
+
     .extents-slider::-webkit-slider-thumb:active {
+        box-shadow: inset 0 0 3px #387bbe, 0 0 9px #387bbe;
+        -webkit-box-shadow: inset 0 0 3px #387bbe, 0 0 9px #387bbe;
+    }
+
+    .extents-slider::-moz-range-thumb:active {
         box-shadow: inset 0 0 3px #387bbe, 0 0 9px #387bbe;
         -webkit-box-shadow: inset 0 0 3px #387bbe, 0 0 9px #387bbe;
     }
@@ -116,8 +125,9 @@ input[type=number]::-webkit-outer-spin-button {
     }
 
     .range-slider::-moz-range-thumb {
-        width: 25px;
-        height: 25px;
-        background: #04AA6D;
+        -moz-appearance: none;
+        appearance: none;
+        height: 6px;
+        background: #25DAA5;
         cursor: pointer;
     }


### PR DESCRIPTION
Fixes #194 

Pseudo css styles for `-webkit-slider-thumb` needed to be added for FF equivalent, which is `-moz-range-thumb`.

Keep in mind, you can't combine both like

    .extents-slider::-webkit-slider-thumb:hover,
    .extents-slider::-moz-range-thumb:hover {
        background: #f7f7f7;
    }

As it then breaks Chrome, which according to ChatGPT can happen when combining pseudo element styles. So best to keep them separate.

Here is before on FF:
![ff_slider_before](https://github.com/user-attachments/assets/f05fa4b2-26d6-4a54-baf3-72ed8f55407c)

And after:
![ff_slider_after](https://github.com/user-attachments/assets/1a0da264-ac71-4e75-96be-9331df3824d8)

Tried moving the min and max thumbs, all good. And dragging the green range, also all good.