### PR TITLE
Update legend explanation for climate record trends

### DIFF
--- a/ClimateExplorer.Web.Client/Shared/PopupContent/ClimateRecordsContent.razor
+++ b/ClimateExplorer.Web.Client/Shared/PopupContent/ClimateRecordsContent.razor
@@ -236,7 +236,7 @@
         <li><b>Pale red, pale blue, or white</b> indicate records from the middle of the dataset.</li>
         <li><b>Blue</b> highlights an early record.</li>
     </ul>
-    <p>When a dataset shows no clear trend, most records are typically set early or somewhere in the middle of the time series. Occasionally, a new record may still appear near the end.</p>
+    <p>When a dataset shows no clear trend, we expect to see records from anywhere in the time series. If you see records that are predominately blue or red in the table above, that is an indication of climate change.</p>
 </InfoPanel>
 
 @code {


### PR DESCRIPTION
Revised the explanatory paragraph below the legend to clarify that, without a trend, records can occur anywhere in the time series. The new text also notes that a predominance of blue or red records indicates climate change.