### PR TITLE
Add lightweight page-load performance instrumentation

### DIFF
--- a/ClimateExplorer.Web.Client/Components/Chart/ChartView.razor.cs
+++ b/ClimateExplorer.Web.Client/Components/Chart/ChartView.razor.cs
@@ -10,6 +10,7 @@ using ClimateExplorer.Core.Infrastructure;
 using ClimateExplorer.Core.Model;
 using ClimateExplorer.Core.ViewModel;
 using ClimateExplorer.Web.Client.Components.Common;
+using ClimateExplorer.Web.Client.Infrastructure;
 using ClimateExplorer.Web.Client.UiModel;
 using ClimateExplorer.Web.UiLogic;
 using ClimateExplorer.Web.UiModel;
@@ -346,6 +347,8 @@ public partial class ChartView : IAsyncDisposable
 
     protected async Task BuildDataSets()
     {
+        using var perf = PerformanceLogScope.Start(Logger!, "ChartView.BuildDataSets", ("pageName", PageName), ("locationId", LocationId), ("seriesCount", ChartSeriesList?.Count ?? 0));
+        await JsRuntime!.InvokeVoidAsync("climateExplorerPerformance.mark", "chart-build-start", new { pageName = PageName, locationId = LocationId, seriesCount = ChartSeriesList?.Count ?? 0 });
         // This method is called whenever anything has occurred that may require the chart to
         // be re-rendered.
         //
@@ -432,16 +435,23 @@ public partial class ChartView : IAsyncDisposable
 
         l.LogInformation("Set ChartSeriesWithData after call to RetrieveDataSets(). ChartSeriesWithData now has " + usableChartSeries.Count() + " entries.");
 
+        await JsRuntime!.InvokeVoidAsync("climateExplorerPerformance.mark", "chart-data-loaded", new { pageName = PageName, locationId = LocationId, seriesCount = ChartSeriesWithData?.Count ?? 0, recordCount = ChartSeriesWithData?.Sum(x => x.SourceDataSet?.DataRecords?.Count ?? 0) ?? 0 });
+
         // Render the series
         await RenderChart();
 
         buildDataSetsInProcess = false;
+
+        await JsRuntime!.InvokeVoidAsync("climateExplorerPerformance.mark", "chart-render-complete", new { pageName = PageName, locationId = LocationId, seriesCount = ChartSeriesWithData?.Count ?? 0 });
+        await JsRuntime!.InvokeVoidAsync("climateExplorerPerformance.measure", "chart-data-load", "chart-build-start", "chart-data-loaded", new { pageName = PageName, locationId = LocationId });
+        await JsRuntime!.InvokeVoidAsync("climateExplorerPerformance.measure", "chart-build-to-render", "chart-build-start", "chart-render-complete", new { pageName = PageName, locationId = LocationId });
 
         l.LogInformation("Leaving");
     }
 
     protected async Task RenderChart()
     {
+        using var perf = PerformanceLogScope.Start(Logger!, "ChartView.RenderChart", ("pageName", PageName), ("locationId", LocationId), ("seriesCount", ChartSeriesWithData?.Count ?? 0));
         var l = new LogAugmenter(Logger!, "RenderChart");
 
         l.LogInformation("Entering");

--- a/ClimateExplorer.Web.Client/Components/Location/LocationDashboard.razor.cs
+++ b/ClimateExplorer.Web.Client/Components/Location/LocationDashboard.razor.cs
@@ -7,6 +7,7 @@ using ClimateExplorer.Core.Model;
 using ClimateExplorer.Core.ViewModel;
 using ClimateExplorer.Web.Client.Components.Common;
 using ClimateExplorer.Web.Client.Components.Info;
+using ClimateExplorer.Web.Client.Infrastructure;
 using ClimateExplorer.Web.Client.Services;
 using ClimateExplorer.Web.Client.UiModel;
 using ClimateExplorer.Web.UiModel;
@@ -109,6 +110,7 @@ public partial class LocationDashboard
 
     protected override async Task OnParametersSetAsync()
     {
+        using var perf = PerformanceLogScope.Start(Logger!, "LocationDashboard.OnParametersSetAsync", ("locationId", Location?.Id), ("locationName", Location?.Name));
         if (Location == null || DataSetDefinitions == null)
         {
             RecentObservationsSupported = false;
@@ -140,6 +142,7 @@ public partial class LocationDashboard
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        using var perf = PerformanceLogScope.Start(Logger!, "LocationDashboard.OnAfterRenderAsync", ("firstRender", firstRender), ("locationId", Location?.Id), ("loadStripeData", LoadStripeData));
         if (Location == null || DataSetDefinitions == null)
         {
             return;
@@ -150,6 +153,8 @@ public partial class LocationDashboard
             LoadStripeData = false;
 
             Logger!.LogInformation("Loading data");
+
+            await JS!.InvokeVoidAsync("climateExplorerPerformance.mark", "location-dashboard-data-start", new { locationId = Location?.Id, locationName = Location?.Name });
 
             var temperatureAnomaly = await CalculateAnomaly(DataSubstitute.StandardTemperatureDataMatches(), ContainerAggregationFunctions.Mean);
             if (temperatureAnomaly != null)
@@ -191,6 +196,9 @@ public partial class LocationDashboard
 
             var recentObservationsSupport = await DataService!.GetRecentObservations(Location!.Id, DataType.TempMax, isLocationSupported: true);
             RecentObservationsSupported = recentObservationsSupport.IsSupported;
+
+            await JS!.InvokeVoidAsync("climateExplorerPerformance.mark", "location-dashboard-data-loaded", new { locationId = Location?.Id, hasTemperatureAnomaly = temperatureAnomaly != null, recentObservationsSupported = RecentObservationsSupported });
+            await JS!.InvokeVoidAsync("climateExplorerPerformance.measure", "location-dashboard-data", "location-dashboard-data-start", "location-dashboard-data-loaded", new { locationId = Location?.Id });
 
             StripeLoadingIndicatorVisible = false;
             StateHasChanged();

--- a/ClimateExplorer.Web.Client/Infrastructure/PerformanceLogScope.cs
+++ b/ClimateExplorer.Web.Client/Infrastructure/PerformanceLogScope.cs
@@ -1,0 +1,39 @@
+namespace ClimateExplorer.Web.Client.Infrastructure;
+
+using System.Diagnostics;
+
+public sealed class PerformanceLogScope : IDisposable
+{
+    private readonly ILogger logger;
+    private readonly string name;
+    private readonly IReadOnlyDictionary<string, object?> context;
+    private readonly long startTimestamp;
+    private bool disposed;
+
+    private PerformanceLogScope(ILogger logger, string name, IReadOnlyDictionary<string, object?> context)
+    {
+        this.logger = logger;
+        this.name = name;
+        this.context = context;
+        startTimestamp = Stopwatch.GetTimestamp();
+
+        logger.LogInformation("PerfStart {Name} {@Context}", name, context);
+    }
+
+    public static PerformanceLogScope Start(ILogger logger, string name, params (string Key, object? Value)[] context)
+    {
+        return new PerformanceLogScope(logger, name, context.ToDictionary(x => x.Key, x => x.Value));
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        var elapsedMilliseconds = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+        logger.LogInformation("PerfEnd {Name} elapsedMs={ElapsedMilliseconds:0.0} {@Context}", name, elapsedMilliseconds, context);
+    }
+}

--- a/ClimateExplorer.Web.Client/Pages/Index.razor.cs
+++ b/ClimateExplorer.Web.Client/Pages/Index.razor.cs
@@ -4,6 +4,7 @@ using ClimateExplorer.Core.Model;
 using ClimateExplorer.Core.ViewModel;
 using ClimateExplorer.Web.Client.Components.Common;
 using ClimateExplorer.Web.Client.Components.Location;
+using ClimateExplorer.Web.Client.Infrastructure;
 using ClimateExplorer.Web.Client.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.WebUtilities;
@@ -73,6 +74,8 @@ public partial class Index : ChartablePage
 
     protected override async Task OnInitializedAsync()
     {
+        using var perf = PerformanceLogScope.Start(Logger!, "Index.OnInitializedAsync", ("locationString", LocationString));
+        await JsRuntime!.InvokeVoidAsync("climateExplorerPerformance.mark", "index-initialized-start", new { locationString = LocationString });
         // Check to see if a named location is being requested. That will look like /location/<location-name>
         Location = await GetLocationFromPath();
 
@@ -105,6 +108,8 @@ public partial class Index : ChartablePage
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        using var perf = PerformanceLogScope.Start(Logger!, "Index.OnAfterRenderAsync", ("firstRender", firstRender), ("hasDataSetDefinitions", DataSetDefinitions is not null), ("locationId", Location?.Id));
+        await JsRuntime!.InvokeVoidAsync("climateExplorerPerformance.mark", firstRender ? "index-first-render-start" : "index-render-start", new { locationId = Location?.Id, hasDataSetDefinitions = DataSetDefinitions is not null });
         if (firstRender)
         {
             SiteOverviewService!.ShowRequested += HandleShowRequested;
@@ -116,7 +121,10 @@ public partial class Index : ChartablePage
             var locationsTask = DataService!.GetLocations(false);
             var regionsTask = DataService!.GetRegions();
 
-            await Task.WhenAll(dataSetDefinitionsTask, locationsTask, regionsTask);
+            using (PerformanceLogScope.Start(Logger!, "Index.LoadReferenceData"))
+            {
+                await Task.WhenAll(dataSetDefinitionsTask, locationsTask, regionsTask);
+            }
 
             DataSetDefinitions = [.. await dataSetDefinitionsTask];
             LocationDictionary = (await locationsTask).ToDictionary(x => x.Id, x => x);
@@ -154,6 +162,9 @@ public partial class Index : ChartablePage
                     await SelectedLocationChanged(Location.Id);
                 }
             }
+
+            await JsRuntime!.InvokeVoidAsync("climateExplorerPerformance.mark", "index-reference-data-loaded", new { locationCount = LocationDictionary?.Count, dataSetDefinitionCount = DataSetDefinitions?.Count(), regionCount = Regions?.Count() });
+            await JsRuntime!.InvokeVoidAsync("climateExplorerPerformance.measure", "index-reference-data", "index-first-render-start", "index-reference-data-loaded", new { locationId = Location?.Id });
 
             StateHasChanged();
         }

--- a/ClimateExplorer.Web/App.razor
+++ b/ClimateExplorer.Web/App.razor
@@ -83,6 +83,7 @@
         the chart to silently fail to initialise and remain stuck on the loading spinner.
         Execution order of the two chart scripts is preserved because they are sequential.
     -->
+    <script src="@Assets["js/performance-instrumentation.js"]"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
             crossorigin="anonymous"

--- a/ClimateExplorer.Web/wwwroot/js/performance-instrumentation.js
+++ b/ClimateExplorer.Web/wwwroot/js/performance-instrumentation.js
@@ -1,0 +1,27 @@
+(function () {
+    const prefix = "ClimateExplorer";
+
+    window.climateExplorerPerformance = {
+        mark: function (name, detail) {
+            if (!window.performance || !window.performance.mark) return;
+            performance.mark(`${prefix}:${name}`, { detail: detail || {} });
+            console.debug(`${prefix}:mark`, name, detail || {});
+        },
+        measure: function (name, startMark, endMark, detail) {
+            if (!window.performance || !window.performance.measure) return;
+            const measureName = `${prefix}:${name}`;
+            const start = `${prefix}:${startMark}`;
+            const end = endMark ? `${prefix}:${endMark}` : undefined;
+            try {
+                performance.measure(measureName, { start: start, end: end, detail: detail || {} });
+                const entries = performance.getEntriesByName(measureName);
+                const latest = entries[entries.length - 1];
+                console.info(`${prefix}:measure`, name, latest ? Math.round(latest.duration) : null, detail || {});
+            } catch (error) {
+                console.debug(`${prefix}:measure skipped`, name, error);
+            }
+        }
+    };
+
+    window.climateExplorerPerformance.mark("document-script-loaded", { url: window.location.href });
+})();

--- a/ClimateExplorer.WebApiClient/Services/DataService.cs
+++ b/ClimateExplorer.WebApiClient/Services/DataService.cs
@@ -7,20 +7,24 @@ using ClimateExplorer.Core.DataPreparation;
 using ClimateExplorer.Core.Model;
 using ClimateExplorer.Core.ViewModel;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
 using static ClimateExplorer.Core.Enums;
 
 public class DataService : IDataService
 {
     private readonly HttpClient httpClient;
     private readonly IDataServiceCache dataServiceCache;
-    private readonly JsonSerializerOptions jsonSerializerOptions;    
+    private readonly JsonSerializerOptions jsonSerializerOptions;
+    private readonly ILogger<DataService> logger;
 
     public DataService(
         HttpClient httpClient,
-        IDataServiceCache dataServiceCache)
+        IDataServiceCache dataServiceCache,
+        ILogger<DataService> logger)
     {
         this.httpClient = httpClient;
         this.dataServiceCache = dataServiceCache;
+        this.logger = logger;
         jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
     }
 
@@ -41,9 +45,11 @@ public class DataService : IDataService
         short? year,
         DataResolution? minimumDataResolution)
     {
+        var endpoint = "dataset";
+        var started = System.Diagnostics.Stopwatch.GetTimestamp();
         var response =
             await httpClient.PostAsJsonAsync(
-                "dataset",
+                endpoint,
                 new PostDataSetsRequestBody
                 {
                     BinAggregationFunction = binAggregationFunction,
@@ -69,6 +75,8 @@ public class DataService : IDataService
         }
 
         var result = await response.Content.ReadFromJsonAsync<DataSet>();
+        var elapsed = System.Diagnostics.Stopwatch.GetElapsedTime(started).TotalMilliseconds;
+        logger.LogInformation("PerfApiClient endpoint={Endpoint} method=POST cached=false elapsedMs={ElapsedMilliseconds:0.0} recordCount={RecordCount} seriesCount={SeriesCount} binGranularity={BinGranularity}", endpoint, elapsed, result?.DataRecords?.Count, seriesSpecifications.Length, binGranularity);
 
         return result!;
     }
@@ -82,13 +90,7 @@ public class DataService : IDataService
     public async Task<IEnumerable<DataSetDefinitionViewModel>> GetDataSetDefinitions()
     {
         var url = "/datasetdefinition";
-        var result = dataServiceCache.Get<DataSetDefinitionViewModel[]>(url);
-        if (result == null)
-        {
-            result = await httpClient.GetFromJsonAsync<DataSetDefinitionViewModel[]>(url, jsonSerializerOptions);
-
-            dataServiceCache.Put(url, result!);
-        }
+        var result = await GetFromJsonWithTiming<DataSetDefinitionViewModel[]>(url, jsonSerializerOptions, cacheable: true);
         
         return result!;
     }
@@ -102,13 +104,7 @@ public class DataService : IDataService
             url = QueryHelpers.AddQueryString(url, "permitCreateCache", permitCreateCache.ToString().ToLowerInvariant());
         }
 
-        var result = dataServiceCache.Get<Location[]>(url);
-        if (result == null)
-        {
-            result = await httpClient.GetFromJsonAsync<Location[]>(url);
-
-            dataServiceCache.Put(url, result!);
-        }
+        var result = await GetFromJsonWithTiming<Location[]>(url, cacheable: true);
 
         return result!;
     }
@@ -128,13 +124,7 @@ public class DataService : IDataService
             url = QueryHelpers.AddQueryString(url, "skip", skip.Value.ToString());
         }
 
-        var result = dataServiceCache.Get<LocationDistance[]>(url);
-        if (result == null)
-        {
-            result = await httpClient.GetFromJsonAsync<LocationDistance[]>(url);
-
-            dataServiceCache.Put(url, result!);
-        }
+        var result = await GetFromJsonWithTiming<LocationDistance[]>(url, cacheable: true);
 
         return result!;
     }
@@ -149,13 +139,7 @@ public class DataService : IDataService
     public async Task<IEnumerable<Region>> GetRegions()
     {
         var url = $"/region";
-        var result = dataServiceCache.Get<Region[]>(url);
-        if (result == null)
-        {
-            result = await httpClient.GetFromJsonAsync<Region[]>(url);
-
-            dataServiceCache.Put(url, result!);
-        }
+        var result = await GetFromJsonWithTiming<Region[]>(url, cacheable: true);
         return result!;
     }
 
@@ -186,9 +170,7 @@ public class DataService : IDataService
         if (result == null)
         {
             var url = $"/heating-score-table";
-            result = await httpClient.GetFromJsonAsync<HeatingScoreRow[]>(url);
-
-            dataServiceCache.Put(heatingScoreTableKey, result!);
+            result = await GetFromJsonWithTiming<HeatingScoreRow[]>(url, cacheable: true);
         }
         
         return result!;
@@ -231,13 +213,7 @@ public class DataService : IDataService
             url = QueryHelpers.AddQueryString(url, "monthly", "true");
         }
 
-        var result = dataServiceCache.Get<ClimateRecordsResponse>(url);
-        if (result == null)
-        {
-            result = await httpClient.GetFromJsonAsync<ClimateRecordsResponse>(url, jsonSerializerOptions);
-
-            dataServiceCache.Put(url, result!);
-        }
+        var result = await GetFromJsonWithTiming<ClimateRecordsResponse>(url, jsonSerializerOptions, cacheable: true);
 
         return result!;
     }
@@ -253,7 +229,42 @@ public class DataService : IDataService
             url = QueryHelpers.AddQueryString(url, "isLocationSupported", "true");
         }
 
-        var result = await httpClient.GetFromJsonAsync<RecentObservationsResponse>(url, jsonSerializerOptions);
+        var result = await GetFromJsonWithTiming<RecentObservationsResponse>(url, jsonSerializerOptions);
         return result!;
     }
+
+
+    private async Task<T> GetFromJsonWithTiming<T>(string url, JsonSerializerOptions? options = null, bool cacheable = false)
+    {
+        var cached = cacheable ? dataServiceCache.Get<T>(url) : default;
+        if (cached is not null)
+        {
+            logger.LogInformation("PerfApiClient endpoint={Endpoint} cached=true elapsedMs={ElapsedMilliseconds:0.0} recordCount={RecordCount}", url, 0, GetRecordCount(cached));
+            return cached;
+        }
+
+        var started = System.Diagnostics.Stopwatch.GetTimestamp();
+        var result = await httpClient.GetFromJsonAsync<T>(url, options);
+        var elapsed = System.Diagnostics.Stopwatch.GetElapsedTime(started).TotalMilliseconds;
+        logger.LogInformation("PerfApiClient endpoint={Endpoint} cached=false elapsedMs={ElapsedMilliseconds:0.0} recordCount={RecordCount} responseType={ResponseType}", url, elapsed, GetRecordCount(result), typeof(T).Name);
+
+        if (cacheable)
+        {
+            dataServiceCache.Put(url, result!);
+        }
+
+        return result!;
+    }
+
+    private static int? GetRecordCount<T>(T? result)
+    {
+        return result switch
+        {
+            System.Collections.ICollection collection => collection.Count,
+            ClimateRecordsResponse response => response.Records?.Count(),
+            RecentObservationsResponse response => response.Records?.Count(),
+            _ => null,
+        };
+    }
+
 }

--- a/docs/performance/page-load-instrumentation.md
+++ b/docs/performance/page-load-instrumentation.md
@@ -1,0 +1,28 @@
+# Page-load performance instrumentation
+
+Issue #647 adds lightweight diagnostics rather than a telemetry provider. Timings appear in two places:
+
+- Browser DevTools console and Performance entries with the `ClimateExplorer:` prefix.
+- Application logs with `PerfStart`, `PerfEnd`, and `PerfApiClient` entries.
+
+## What is instrumented
+
+- Initial location page lifecycle (`Index.OnInitializedAsync`, `Index.OnAfterRenderAsync`).
+- Reference data loading for dataset definitions, location dictionary, and regions.
+- Location dashboard data loading, including anomaly, climate stripe, and recent-observation support paths.
+- Chart dataset preparation and rendering.
+- API client GET calls, including endpoint, cached/uncached state, elapsed milliseconds, response type, and record counts where available.
+
+## How to compare timings locally
+
+1. Run the Web and WebApi projects locally.
+2. Open DevTools and keep the Console and Performance tabs open.
+3. Load `/`, `/location/{id}`, and a regional/global page once with cache disabled, then again with normal cache enabled.
+4. Compare `ClimateExplorer:measure` browser timings and `PerfApiClient` log lines between cold and warm loads.
+
+## Suspicious paths to watch first
+
+- The first `Index.LoadReferenceData` block, because it downloads the location dictionary and all dataset definitions before the default location dashboard can be fully selected.
+- `LocationDashboard.OnAfterRenderAsync`, because it intentionally defers anomaly/stripe work until after first render but still controls perceived dashboard completion.
+- Chart `PostDataSet` requests triggered from `ChartView.BuildDataSets`, because chart rendering waits on all selected series data.
+- Repeated `PerfApiClient cached=false` lines for the same endpoint during one navigation, which would indicate duplicated or unexpectedly early API calls.


### PR DESCRIPTION
### Motivation

- Provide lightweight, low-cost diagnostics to measure page-load and chart-render performance without adding a full telemetry provider.  
- Make it easier to triage slow paths (reference data, dashboard anomaly/stripe work, and chart dataset preparation).  
- Capture API client timings (including cache state and record counts) to spot expensive or duplicated requests.

### Description

- Added a reusable C# timing scope `PerformanceLogScope` at `ClimateExplorer.Web.Client/Infrastructure/PerformanceLogScope.cs` that emits `PerfStart`/`PerfEnd` log lines with elapsed milliseconds and contextual fields.  
- Added a small browser helper `window.climateExplorerPerformance` in `ClimateExplorer.Web/wwwroot/js/performance-instrumentation.js` and load it from the app shell (`ClimateExplorer.Web/App.razor`) to emit `ClimateExplorer:` Performance marks/measures to DevTools and the Performance timeline.  
- Instrumented key client lifecycle and UI paths with both server logs and browser marks: `Index` page lifecycle and reference-data load (`Index.razor.cs`), `LocationDashboard` deferred data loading (`LocationDashboard.razor.cs`), and chart build/render flows in `ChartView` (`ChartView.razor.cs`).  
- Enhanced the API client (`ClimateExplorer.WebApiClient/Services/DataService.cs`) to log `PostDataSet` timings and to centralise GET timings via `GetFromJsonWithTiming`, including cache state and record counts; added `docs/performance/page-load-instrumentation.md` describing instrumentation and how to compare cold/warm loads.

### Testing

- Ran `git diff --check` to validate whitespace and basic diffs, which succeeded.  
- Attempted `dotnet build ClimateExplorer.sln`, but the build could not be executed in this environment because `dotnet` is not installed (automated build unavailable here).  
- No runtime/integration tests were run in this container due to missing .NET SDK; manual verification is documented in `docs/performance/page-load-instrumentation.md` for local testing with the full dev setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a334d3697b483228e99493e1f72af9f)