### PR TITLE
Place recent observation record badges

### DIFF
--- a/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor
+++ b/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor
@@ -11,14 +11,14 @@
     <h3>@Tile.Headline</h3>
     <p class="recent-observation-percentile">@Tile.PercentileSentence</p>
     <div class="recent-observation-primary">
-        <span class="recent-observation-primary-label">
-            @Tile.PrimaryLabel
+        <span class="recent-observation-primary-label">@Tile.PrimaryLabel</span>
+        <span class="recent-observation-primary-value">
             @if (!string.IsNullOrWhiteSpace(Tile.PrimaryRecordStatusText))
             {
                 <span class="recent-observation-status status-@StatusClass(Tile.PrimaryRecordStatus)">@Tile.PrimaryRecordStatusText</span>
             }
+            <strong>@Tile.PrimaryValue</strong>
         </span>
-        <strong>@Tile.PrimaryValue</strong>
     </div>
     @if (Tile.Stats.Count > 0)
     {
@@ -119,7 +119,7 @@
                                         <span class="recent-observation-detail-current">@metric.CurrentValue</span>
                                         @if (!string.IsNullOrWhiteSpace(metric.RecordStatusText))
                                         {
-                                            <span class="recent-observation-detail-status status-@StatusClass(metric.RecordStatus)">@metric.RecordStatusText</span>
+                                            <span class="recent-observation-status status-@StatusClass(metric.RecordStatus)">@metric.RecordStatusText</span>
                                         }
                                         else if (!string.IsNullOrWhiteSpace(metric.RankText))
                                         {

--- a/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor
+++ b/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor
@@ -11,7 +11,13 @@
     <h3>@Tile.Headline</h3>
     <p class="recent-observation-percentile">@Tile.PercentileSentence</p>
     <div class="recent-observation-primary">
-        <span>@Tile.PrimaryLabel</span>
+        <span class="recent-observation-primary-label">
+            @Tile.PrimaryLabel
+            @if (!string.IsNullOrWhiteSpace(Tile.PrimaryRecordStatusText))
+            {
+                <span class="recent-observation-status status-@StatusClass(Tile.PrimaryRecordStatus)">@Tile.PrimaryRecordStatusText</span>
+            }
+        </span>
         <strong>@Tile.PrimaryValue</strong>
     </div>
     @if (Tile.Stats.Count > 0)
@@ -21,7 +27,13 @@
             {
                 <div>
                     <dt>@stat.Label</dt>
-                    <dd>@stat.Value</dd>
+                    <dd>
+                        <span class="recent-observation-stat-value">@stat.Value</span>
+                        @if (!string.IsNullOrWhiteSpace(stat.RecordStatusText))
+                        {
+                            <span class="recent-observation-status recent-observation-stat-status status-@StatusClass(stat.RecordStatus)">@stat.RecordStatusText</span>
+                        }
+                    </dd>
                 </div>
             }
         </dl>
@@ -65,7 +77,13 @@
             {
                 <div>
                     <dt>@stat.Label</dt>
-                    <dd>@stat.Value</dd>
+                    <dd>
+                        <span class="recent-observation-stat-value">@stat.Value</span>
+                        @if (!string.IsNullOrWhiteSpace(stat.RecordStatusText))
+                        {
+                            <span class="recent-observation-status recent-observation-stat-status status-@StatusClass(stat.RecordStatus)">@stat.RecordStatusText</span>
+                        }
+                    </dd>
                 </div>
             }
         </dl>

--- a/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor
+++ b/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor
@@ -31,7 +31,7 @@
                         <span class="recent-observation-stat-value">@stat.Value</span>
                         @if (!string.IsNullOrWhiteSpace(stat.RecordStatusText))
                         {
-                            <span class="recent-observation-status recent-observation-stat-status status-@StatusClass(stat.RecordStatus)">@stat.RecordStatusText</span>
+                            <span class="recent-observation-status status-@StatusClass(stat.RecordStatus)">@stat.RecordStatusText</span>
                         }
                     </dd>
                 </div>
@@ -81,7 +81,7 @@
                         <span class="recent-observation-stat-value">@stat.Value</span>
                         @if (!string.IsNullOrWhiteSpace(stat.RecordStatusText))
                         {
-                            <span class="recent-observation-status recent-observation-stat-status status-@StatusClass(stat.RecordStatus)">@stat.RecordStatusText</span>
+                            <span class="recent-observation-status status-@StatusClass(stat.RecordStatus)">@stat.RecordStatusText</span>
                         }
                     </dd>
                 </div>

--- a/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor.css
+++ b/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor.css
@@ -85,35 +85,45 @@
 }
 
 .recent-observation-primary-label {
-    align-items: center;
     color: #596f6a;
-    display: inline-flex;
-    flex-wrap: wrap;
+    flex: 1 1 auto;
     font-size: 0.82rem;
     font-weight: 700;
+    min-width: 0;
+}
+
+.recent-observation-primary-value {
+    align-items: baseline;
+    display: inline-flex;
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
     gap: 0.35rem;
+    justify-content: flex-end;
+    margin-left: auto;
+    text-align: right;
+    white-space: nowrap;
 }
 
 .recent-observation-status {
     border-radius: 999px;
     display: inline-block;
-    font-size: 0.62rem;
-    font-weight: 800;
+    font-size: 0.68rem;
+    font-weight: 700;
     letter-spacing: 0.035em;
     line-height: 1;
-    padding: 0.18rem 0.4rem;
+    padding: 0.08rem 0.4rem;
     text-transform: uppercase;
     white-space: nowrap;
 }
 
 .recent-observation-status.status-new {
-    background: #7a3f1e;
-    color: #fff7ef;
+    background: #d8efe0;
+    color: #1f6b41;
 }
 
 .recent-observation-status.status-equal {
-    background: #4d5f73;
-    color: #f3f7fb;
+    background: #e7eef0;
+    color: #3a5b73;
 }
 
 .recent-observation-primary strong {
@@ -183,19 +193,23 @@
 }
 
 .recent-observation-stats dd {
+    align-items: baseline;
     color: #263a35;
+    display: flex;
+    flex-wrap: wrap;
     font-size: 0.92rem;
     font-weight: 650;
+    gap: 0.35rem;
     margin: 0;
     overflow-wrap: anywhere;
 }
 
 .recent-observation-stat-value {
-    display: block;
+    display: inline-block;
 }
 
 .recent-observation-stat-status {
-    margin-top: 0.22rem;
+    margin-top: 0;
 }
 
 .recent-observation-note {
@@ -325,24 +339,6 @@
 
 .recent-observation-detail-record-label {
     color: #697d78;
-}
-
-.recent-observation-detail-status {
-    border-radius: 4px;
-    font-size: 0.68rem;
-    font-weight: 700;
-    padding: 0.08rem 0.4rem;
-    text-transform: uppercase;
-}
-
-.recent-observation-detail-status.status-new {
-    background: #d8efe0;
-    color: #1f6b41;
-}
-
-.recent-observation-detail-status.status-equal {
-    background: #e7eef0;
-    color: #3a5b73;
 }
 
 @media (min-width: 641px) {

--- a/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor.css
+++ b/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor.css
@@ -92,15 +92,17 @@
     min-width: 0;
 }
 
-.recent-observation-primary-value {
+.recent-observation-primary-value,
+.recent-observation-stats dd {
     align-items: baseline;
-    display: inline-flex;
+    display: flex;
+    gap: 0.35rem;
+}
+
+.recent-observation-primary-value {
     flex: 0 0 auto;
     flex-wrap: nowrap;
-    gap: 0.35rem;
     justify-content: flex-end;
-    margin-left: auto;
-    text-align: right;
     white-space: nowrap;
 }
 
@@ -193,23 +195,16 @@
 }
 
 .recent-observation-stats dd {
-    align-items: baseline;
     color: #263a35;
-    display: flex;
     flex-wrap: wrap;
     font-size: 0.92rem;
     font-weight: 650;
-    gap: 0.35rem;
     margin: 0;
     overflow-wrap: anywhere;
 }
 
 .recent-observation-stat-value {
     display: inline-block;
-}
-
-.recent-observation-stat-status {
-    margin-top: 0;
 }
 
 .recent-observation-note {

--- a/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor.css
+++ b/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationTile.razor.css
@@ -84,10 +84,36 @@
     padding-top: 0.75rem;
 }
 
-.recent-observation-primary span {
+.recent-observation-primary-label {
+    align-items: center;
     color: #596f6a;
+    display: inline-flex;
+    flex-wrap: wrap;
     font-size: 0.82rem;
     font-weight: 700;
+    gap: 0.35rem;
+}
+
+.recent-observation-status {
+    border-radius: 999px;
+    display: inline-block;
+    font-size: 0.62rem;
+    font-weight: 800;
+    letter-spacing: 0.035em;
+    line-height: 1;
+    padding: 0.18rem 0.4rem;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.recent-observation-status.status-new {
+    background: #7a3f1e;
+    color: #fff7ef;
+}
+
+.recent-observation-status.status-equal {
+    background: #4d5f73;
+    color: #f3f7fb;
 }
 
 .recent-observation-primary strong {
@@ -162,6 +188,14 @@
     font-weight: 650;
     margin: 0;
     overflow-wrap: anywhere;
+}
+
+.recent-observation-stat-value {
+    display: block;
+}
+
+.recent-observation-stat-status {
+    margin-top: 0.22rem;
 }
 
 .recent-observation-note {

--- a/ClimateExplorer.Web.Client/Services/RecentObservationsCalculator.cs
+++ b/ClimateExplorer.Web.Client/Services/RecentObservationsCalculator.cs
@@ -612,13 +612,20 @@ public sealed class RecentObservationsCalculator : IRecentObservationsCalculator
         {
             if (period.MetricValues.TryGetValue(metric.Key, out var value))
             {
+                var status = GetRecordStatus(value, distributions.GetValueOrDefault(metric.Key));
                 supportingStats.Add(new RecentObservationStatViewModel
                 {
                     Label = singular ? metric.SingularLabel : metric.PluralLabel,
                     Value = metric.Format(value),
+                    RecordStatus = status,
+                    RecordStatusText = FormatCollapsedRecordStatus(status),
                 });
             }
         }
+
+        var primaryStatus = ranking is null
+            ? RecentObservationRecordStatus.None
+            : RecentObservationComparison.DetermineRecordStatus(ranking);
 
         if (ranking is not null)
         {
@@ -643,6 +650,8 @@ public sealed class RecentObservationsCalculator : IRecentObservationsCalculator
             PercentileSentence = BuildPercentileSentence(period, domain, historicalValues, ranking),
             PrimaryLabel = domain.PrimaryLabel,
             PrimaryValue = domain.Primary.Format(primaryValue),
+            PrimaryRecordStatus = primaryStatus,
+            PrimaryRecordStatusText = FormatCollapsedRecordStatus(primaryStatus),
             HistoricalMaxLabel = showHistoricalRange ? $"{domain.HistoricalMaxWord} {historicalContext}" : null,
             HistoricalMaxValue = showHistoricalRange ? domain.Primary.Format(ranking!.HistoricalMax) : null,
             HistoricalMaxOccurred = showHistoricalRange ? FormatHistoricalOccurrence(historicalValues.MaxValue) : null,
@@ -662,6 +671,27 @@ public sealed class RecentObservationsCalculator : IRecentObservationsCalculator
             CanShowPercentile = historicalValues.CanShowPercentile,
             AvailableObservationCount = period.Completeness.AvailableObservationCount,
             ExpectedObservationCount = period.Completeness.ExpectedObservationCount,
+        };
+    }
+
+    private static RecentObservationRecordStatus GetRecordStatus(double currentValue, HistoricalValues? distribution)
+    {
+        var ranking = distribution is null
+            ? null
+            : RecentObservationComparison.Rank(currentValue, distribution.Values);
+
+        return ranking is null
+            ? RecentObservationRecordStatus.None
+            : RecentObservationComparison.DetermineRecordStatus(ranking);
+    }
+
+    private static string? FormatCollapsedRecordStatus(RecentObservationRecordStatus status)
+    {
+        return status switch
+        {
+            RecentObservationRecordStatus.NewRecord => "NEW RECORD",
+            RecentObservationRecordStatus.EqualRecord => "EQUAL RECORD",
+            _ => null,
         };
     }
 

--- a/ClimateExplorer.Web.Client/UiModel/RecentObservationStatViewModel.cs
+++ b/ClimateExplorer.Web.Client/UiModel/RecentObservationStatViewModel.cs
@@ -1,7 +1,11 @@
 namespace ClimateExplorer.Web.Client.UiModel;
 
+using ClimateExplorer.Core.Calculators;
+
 public sealed record RecentObservationStatViewModel
 {
     public string Label { get; init; } = string.Empty;
     public string Value { get; init; } = string.Empty;
+    public RecentObservationRecordStatus RecordStatus { get; init; }
+    public string? RecordStatusText { get; init; }
 }

--- a/ClimateExplorer.Web.Client/UiModel/RecentObservationTileViewModel.cs
+++ b/ClimateExplorer.Web.Client/UiModel/RecentObservationTileViewModel.cs
@@ -1,5 +1,7 @@
 namespace ClimateExplorer.Web.Client.UiModel;
 
+using ClimateExplorer.Core.Calculators;
+
 public sealed record RecentObservationTileViewModel
 {
     public RecentObservationPeriodKind PeriodKind { get; init; }
@@ -12,6 +14,8 @@ public sealed record RecentObservationTileViewModel
     public string PercentileSentence { get; init; } = string.Empty;
     public string PrimaryLabel { get; init; } = string.Empty;
     public string PrimaryValue { get; init; } = string.Empty;
+    public RecentObservationRecordStatus PrimaryRecordStatus { get; init; }
+    public string? PrimaryRecordStatusText { get; init; }
     public string? HistoricalMaxLabel { get; init; }
     public string? HistoricalMaxValue { get; init; }
     public string? HistoricalMaxOccurred { get; init; }
@@ -65,6 +69,8 @@ public sealed record RecentObservationTileViewModel
             CanShowHistoricalRange = false,
             CanShowRank = false,
             CanShowPercentile = false,
+            PrimaryRecordStatus = RecentObservationRecordStatus.None,
+            PrimaryRecordStatusText = null,
             Tone = RecentObservationTileTone.Unavailable,
             Note = note,
             MetricGroups = StripComparisons(MetricGroups),


### PR DESCRIPTION
### Motivation
- Surface historical-record status in collapsed recent-observation tiles so users can see when the primary metric or supporting stats are a new/equal record without expanding the tile.
- Keep the existing layout and completeness-threshold behavior while exposing compact record badges for quick scanning.

### Description
- Add `PrimaryRecordStatus` and `PrimaryRecordStatusText` to `RecentObservationTileViewModel` and `RecordStatus`/`RecordStatusText` to `RecentObservationStatViewModel` so collapsed tiles can carry record metadata.
- Compute collapsed-tile statuses in `RecentObservationsCalculator.BuildTile` by adding `GetRecordStatus` and `FormatCollapsedRecordStatus` helpers and populate the new view-model fields for primary and supporting stats.
- Update `RecentObservationTile.razor` to render a compact lozenge next to the primary label and to render supporting-stat lozenges beneath the stat values when present.
- Add shared CSS rules in `RecentObservationTile.razor.css` for the lozenge styles and minor layout tweaks to keep the primary value right-aligned.

### Testing
- Ran `git diff --check` to validate the working tree formatting and found no issues (passed).
- Attempted `dotnet test ClimateExplorer.sln` to run unit tests but the `dotnet` CLI is not available in this environment (could not run tests).
- Verified local code changes and component markup render points via repository inspection commands (no runtime UI test executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34cb961dfc8322b99829430a87589d)