### PR TITLE
Handle per-series chartability in chart data pipeline

### DIFF
--- a/ClimateExplorer.UnitTests/ChartDataBuilderTests.cs
+++ b/ClimateExplorer.UnitTests/ChartDataBuilderTests.cs
@@ -140,9 +140,102 @@ public class ChartDataBuilderTests
         Assert.IsTrue(result.HasRenderableData);
         Assert.HasCount(1, result.Messages);
         StringAssert.Contains(result.Messages.Single().Message, "moving");
+        Assert.AreEqual(ChartSeriesDataStatus.FallbackToUnsmoothedData, result.SeriesWithData.Single().DataStatus);
 
         var processedValues = result.SeriesWithData.Single().ProcessedDataSet!.DataRecords.Select(x => x.Value).ToArray();
         CollectionAssert.AreEqual(new double?[] { 1, 2, 3, 4, 5 }, processedValues);
+    }
+
+    [TestMethod]
+    public async Task BuildRendersAvailableSeriesWhenAnotherSeriesHasNoChartableDataAfterCompletenessFiltering()
+    {
+        var temperatureDataSet = CreateYearDataSet([(2000, 10), (2001, 11), (2002, 12)]);
+        var precipitationDataSet = CreateYearDataSet(
+            [],
+            DataType.Precipitation,
+            UnitOfMeasure.Millimetres,
+            rawDataRecords: [new DataRecord(2000, 1, 1, 1)]);
+        var dataService = CreateSequentialDataService(temperatureDataSet, precipitationDataSet);
+
+        var temperatureSeries = CreateSeries();
+        var precipitationSeries = CreateSeries(
+            dataType: DataType.Precipitation,
+            unitOfMeasure: UnitOfMeasure.Millimetres,
+            aggregation: SeriesAggregationOptions.Sum);
+        var state = new ChartState { ChartAllData = true, Series = [temperatureSeries, precipitationSeries] };
+
+        var result = await CreateBuilder(dataService).BuildAsync(state);
+
+        Assert.IsTrue(result.HasRenderableData);
+        Assert.HasCount(1, result.SeriesWithData);
+        Assert.AreSame(temperatureSeries, result.SeriesWithData.Single().ChartSeries);
+        Assert.HasCount(1, result.NonRenderedSeriesWithData);
+        Assert.AreSame(precipitationSeries, result.NonRenderedSeriesWithData.Single().ChartSeries);
+        Assert.AreEqual(ChartSeriesDataStatus.NoChartableDataAfterCompletenessFiltering, result.NonRenderedSeriesWithData.Single().DataStatus);
+        Assert.HasCount(1, result.Messages);
+        StringAssert.Contains(result.Messages.Single().Message, "completeness threshold removed all precipitation observations");
+        Assert.HasCount(2, state.Series);
+
+        var processedValues = result.SeriesWithData.Single().ProcessedDataSet!.DataRecords.Select(x => x.Value).ToArray();
+        CollectionAssert.AreEqual(new double?[] { 10, 11, 12 }, processedValues);
+    }
+
+    [TestMethod]
+    public async Task BuildReturnsFullNoDataResultOnlyWhenNoRequestedSeriesHasChartableData()
+    {
+        var solarDataSet = CreateYearDataSet(
+            [],
+            DataType.SolarRadiation,
+            UnitOfMeasure.MegajoulesPerSquareMetre,
+            rawDataRecords: [new DataRecord(2000, 1, 1, 20)]);
+        var dataService = CreateDataService(solarDataSet);
+
+        var series = CreateSeries(
+            dataType: DataType.SolarRadiation,
+            unitOfMeasure: UnitOfMeasure.MegajoulesPerSquareMetre);
+        var state = new ChartState { ChartAllData = true, Series = [series] };
+
+        var result = await CreateBuilder(dataService).BuildAsync(state);
+
+        Assert.IsFalse(result.HasRenderableData);
+        Assert.IsEmpty(result.SeriesWithData);
+        Assert.HasCount(1, result.NonRenderedSeriesWithData);
+        Assert.AreEqual(ChartSeriesDataStatus.NoChartableDataAfterCompletenessFiltering, result.NonRenderedSeriesWithData.Single().DataStatus);
+        Assert.HasCount(1, result.Messages);
+        StringAssert.Contains(result.Messages.Single().Message, "completeness threshold removed all solar radiation observations");
+    }
+
+    [TestMethod]
+    public async Task BuildRendersPreviouslySkippedSeriesWhenNextResultHasChartableData()
+    {
+        var emptyPrecipitationDataSet = CreateYearDataSet(
+            [],
+            DataType.Precipitation,
+            UnitOfMeasure.Millimetres,
+            rawDataRecords: [new DataRecord(2000, 1, 1, 1)]);
+        var validPrecipitationDataSet = CreateYearDataSet(
+            [(2000, 100), (2001, 110)],
+            DataType.Precipitation,
+            UnitOfMeasure.Millimetres);
+        var dataService = CreateSequentialDataService(emptyPrecipitationDataSet, validPrecipitationDataSet);
+
+        var series = CreateSeries(
+            dataType: DataType.Precipitation,
+            unitOfMeasure: UnitOfMeasure.Millimetres,
+            aggregation: SeriesAggregationOptions.Sum);
+        var state = new ChartState { ChartAllData = true, Series = [series] };
+        var builder = CreateBuilder(dataService);
+
+        var firstResult = await builder.BuildAsync(state);
+        var secondResult = await builder.BuildAsync(state);
+
+        Assert.IsFalse(firstResult.HasRenderableData);
+        Assert.HasCount(1, firstResult.NonRenderedSeriesWithData);
+        Assert.IsTrue(secondResult.HasRenderableData);
+        Assert.HasCount(1, secondResult.SeriesWithData);
+        Assert.IsEmpty(secondResult.NonRenderedSeriesWithData);
+        Assert.AreEqual(ChartSeriesDataStatus.Rendered, secondResult.SeriesWithData.Single().DataStatus);
+        Assert.HasCount(1, state.Series);
     }
 
     private static ChartDataBuilder CreateBuilder(Mock<IDataService> dataService)
@@ -174,13 +267,43 @@ public class ChartDataBuilderTests
         return dataService;
     }
 
-    private static DataSet CreateYearDataSet(IEnumerable<(int Year, double? Value)> records)
+    private static Mock<IDataService> CreateSequentialDataService(params DataSet[] dataSets)
+    {
+        var queue = new Queue<DataSet>(dataSets);
+        var dataService = new Mock<IDataService>();
+        dataService
+            .Setup(x => x.PostDataSet(
+                It.IsAny<BinGranularities>(),
+                It.IsAny<ContainerAggregationFunctions>(),
+                It.IsAny<ContainerAggregationFunctions>(),
+                It.IsAny<ContainerAggregationFunctions>(),
+                It.IsAny<SeriesValueOptions>(),
+                It.IsAny<SeriesSpecification[]>(),
+                It.IsAny<SeriesDerivationTypes>(),
+                It.IsAny<float>(),
+                It.IsAny<float>(),
+                It.IsAny<float>(),
+                It.IsAny<int>(),
+                It.IsAny<SeriesTransformations>(),
+                It.IsAny<string?>(),
+                It.IsAny<short?>(),
+                It.IsAny<DataResolution?>()))
+            .ReturnsAsync(() => queue.Dequeue());
+        return dataService;
+    }
+
+    private static DataSet CreateYearDataSet(
+        IEnumerable<(int Year, double? Value)> records,
+        DataType dataType = DataType.TempMean,
+        UnitOfMeasure unitOfMeasure = UnitOfMeasure.DegreesCelsius,
+        DataRecord[]? rawDataRecords = null)
     {
         return new DataSet
         {
             GeographicalEntity = CreateLocation(),
-            MeasurementDefinition = CreateMeasurementDefinition(),
+            MeasurementDefinition = CreateMeasurementDefinition(dataType, unitOfMeasure),
             DataRecords = [.. records.Select(r => new BinnedRecord(new YearBinIdentifier((short)r.Year).Id, r.Value))],
+            RawDataRecords = rawDataRecords,
         };
     }
 
@@ -196,18 +319,22 @@ public class ChartDataBuilderTests
         };
     }
 
-    private static MeasurementDefinitionViewModel CreateMeasurementDefinition()
+    private static MeasurementDefinitionViewModel CreateMeasurementDefinition(
+        DataType dataType = DataType.TempMean,
+        UnitOfMeasure unitOfMeasure = UnitOfMeasure.DegreesCelsius)
     {
         return new MeasurementDefinitionViewModel
         {
-            DataType = DataType.TempMean,
+            DataType = dataType,
             DataAdjustment = DataAdjustment.Adjusted,
             DataResolution = DataResolution.Monthly,
-            UnitOfMeasure = UnitOfMeasure.DegreesCelsius,
+            UnitOfMeasure = unitOfMeasure,
         };
     }
 
-    private static DataSetDefinitionViewModel CreateDataSetDefinition()
+    private static DataSetDefinitionViewModel CreateDataSetDefinition(
+        DataType dataType = DataType.TempMean,
+        UnitOfMeasure unitOfMeasure = UnitOfMeasure.DegreesCelsius)
     {
         return new DataSetDefinitionViewModel
         {
@@ -215,7 +342,7 @@ public class ChartDataBuilderTests
             Name = "Test data set",
             ShortName = "Test",
             LocationIds = [LocationId],
-            MeasurementDefinitions = [CreateMeasurementDefinition()],
+            MeasurementDefinitions = [CreateMeasurementDefinition(dataType, unitOfMeasure)],
         };
     }
 
@@ -223,9 +350,12 @@ public class ChartDataBuilderTests
         BinGranularities binGranularity = BinGranularities.ByYear,
         SecondaryCalculationOptions secondaryCalculation = SecondaryCalculationOptions.None,
         SeriesSmoothingOptions smoothing = SeriesSmoothingOptions.None,
-        int smoothingWindow = 20)
+        int smoothingWindow = 20,
+        DataType dataType = DataType.TempMean,
+        UnitOfMeasure unitOfMeasure = UnitOfMeasure.DegreesCelsius,
+        SeriesAggregationOptions aggregation = SeriesAggregationOptions.Mean)
     {
-        var dataSetDefinition = CreateDataSetDefinition();
+        var dataSetDefinition = CreateDataSetDefinition(dataType, unitOfMeasure);
 
         return new ChartSeriesDefinition
         {
@@ -240,7 +370,7 @@ public class ChartDataBuilderTests
                     MeasurementDefinition = dataSetDefinition.MeasurementDefinitions!.Single(),
                 },
             ],
-            Aggregation = SeriesAggregationOptions.Mean,
+            Aggregation = aggregation,
             BinGranularity = binGranularity,
             DisplayStyle = SeriesDisplayStyle.Line,
             SecondaryCalculation = secondaryCalculation,

--- a/ClimateExplorer.Web.Client/Components/Chart/ChartView.razor.cs
+++ b/ClimateExplorer.Web.Client/Components/Chart/ChartView.razor.cs
@@ -2,7 +2,6 @@ namespace ClimateExplorer.Web.Client.Components.Chart;
 
 using Blazorise.Charts;
 using Blazorise.Charts.Trendline;
-using ClimateExplorer.Core;
 using ClimateExplorer.Core.DataPreparation;
 using ClimateExplorer.Core.Infrastructure;
 using ClimateExplorer.Core.Model;
@@ -108,7 +107,6 @@ public partial class ChartView : IAsyncDisposable
 
     private bool? IsMobileDevice { get; set; }
 
-    private List<short>? SelectedYears { get; set; }
     private List<short>? StartYears { get; set; }
 
     private ColourServer Colours { get; set; } = new ColourServer();
@@ -144,8 +142,6 @@ public partial class ChartView : IAsyncDisposable
     {
         ChartLoadingIndicatorVisible = true;
         ChartLoadingErrored = false;
-
-        SelectedYears = [];
 
         SelectedGroupingDays = 14;
         GroupingThresholdText = "70";

--- a/ClimateExplorer.Web.Client/Services/Chart/ChartDataBuildResult.cs
+++ b/ClimateExplorer.Web.Client/Services/Chart/ChartDataBuildResult.cs
@@ -14,6 +14,8 @@ public sealed record ChartDataBuildResult
 {
     public IReadOnlyList<SeriesWithData> SeriesWithData { get; init; } = [];
 
+    public IReadOnlyList<SeriesWithData> NonRenderedSeriesWithData { get; init; } = [];
+
     public BinIdentifier[]? ChartBins { get; init; }
 
     public BinIdentifier? ChartStartBin { get; init; }

--- a/ClimateExplorer.Web.Client/Services/Chart/ChartDataBuilder.cs
+++ b/ClimateExplorer.Web.Client/Services/Chart/ChartDataBuilder.cs
@@ -106,6 +106,23 @@ public sealed class ChartDataBuilder : IChartDataBuilder
         return [.. dataSet.Select(x => x!.GetStartYearForDataSet()).Distinct().OrderBy(x => x)];
     }
 
+    private static SnackbarMessage CreateCompletenessFilteringMessage(DataSet dataSet)
+    {
+        var dataType = dataSet.DataType.ToFriendlyName().ToLowerInvariant();
+        var locationName = dataSet.GeographicalEntity?.ToString() ?? "the selected location";
+
+        return new SnackbarMessage
+        {
+            Message = $"The completeness threshold removed all {dataType} observations for {locationName}.<br>There is not enough complete {dataType} data to chart this series.",
+            Type = SnackbarColor.Warning,
+        };
+    }
+
+    private static bool HasFiniteValue(DataSet? dataSet)
+    {
+        return dataSet?.DataRecords.Any(x => x.Value.HasValue && !double.IsNaN(x.Value.Value) && !double.IsInfinity(x.Value.Value)) == true;
+    }
+
     private async Task<List<SeriesWithData>> RetrieveDataSets(
         IReadOnlyList<ChartSeriesDefinition> chartSeriesList,
         BinGranularities binGranularity,
@@ -202,8 +219,6 @@ public sealed class ChartDataBuilder : IChartDataBuilder
             }
         }
 
-        var badChartSeries = new List<SeriesWithData>();
-
         // If we're doing smoothing via the moving average, precalculate these data and add them to PreProcessedDataSets.
         // We do this because the SimpleMovingAverage calculate function will remove some years from the start of the data set.
         // It removes these years because it doesn't have a good enough average to present it to the user.
@@ -211,6 +226,14 @@ public sealed class ChartDataBuilder : IChartDataBuilder
         // If we're not calculating a moving average, PreProcessedDataSets = SourceDataSets
         foreach (var cs in chartSeriesWithData)
         {
+            if (!HasFiniteValue(cs.SourceDataSet))
+            {
+                cs.DataStatus = ChartSeriesDataStatus.NoChartableDataAfterCompletenessFiltering;
+                cs.PreProcessedDataSet = cs.SourceDataSet;
+                messages.Add(CreateCompletenessFilteringMessage(cs.SourceDataSet));
+                continue;
+            }
+
             // We only support moving averages on linear bin granularities (e.g. Year, YearAndMonth) - not modular ones like MonthOnly
             if (selectedBinGranularity.IsLinear() && cs.ChartSeries!.Smoothing == SeriesSmoothingOptions.MovingAverage)
             {
@@ -222,6 +245,7 @@ public sealed class ChartDataBuilder : IChartDataBuilder
                 if (values.Count(y => y != null) < 10)
                 {
                     messages.Add(new SnackbarMessage { Message = $"The moving‑average removed too many {cs.SourceDataSet.DataType.ToFriendlyName().ToLower()} observations for {cs.SourceDataSet.GeographicalEntity?.Name}.<br>We will revert to using the unsmoothed data.", Type = SnackbarColor.Warning });
+                    cs.DataStatus = ChartSeriesDataStatus.FallbackToUnsmoothedData;
                     values = cs.SourceDataSet.DataRecords
                                             .Where(x => x.Value.HasValue)
                                             .Select(x => x.Value);
@@ -249,12 +273,26 @@ public sealed class ChartDataBuilder : IChartDataBuilder
             }
         }
 
-        badChartSeries.ForEach(x => chartSeriesWithData.Remove(x));
+        var renderableChartSeries = chartSeriesWithData
+            .Where(x => HasFiniteValue(x.PreProcessedDataSet))
+            .ToList();
+
+        if (renderableChartSeries.Count == 0)
+        {
+            l.LogWarning("No requested chart series produced finite values after preprocessing.");
+
+            return new ChartDataBuildResult
+            {
+                SeriesWithData = [],
+                NonRenderedSeriesWithData = chartSeriesWithData,
+                StartYears = [],
+            };
+        }
 
         l.LogInformation("done with moving average calculation");
 
         // There must be exactly one bin granularity or else something odd's going on.
-        var binGranularity = chartSeriesWithData.Select(x => x.ChartSeries!.BinGranularity).Distinct().Single();
+        var binGranularity = renderableChartSeries.Select(x => x.ChartSeries!.BinGranularity).Distinct().Single();
 
         if (binGranularity != selectedBinGranularity)
         {
@@ -273,7 +311,7 @@ public sealed class ChartDataBuilder : IChartDataBuilder
             case BinGranularities.ByYearAndWeek:
             case BinGranularities.ByYearAndDay:
                 // Calculate first and last year which we have a data record for, across all data sets underpinning all chart series
-                var preProcessedDataSets = chartSeriesWithData.Select(x => x.PreProcessedDataSet);
+                var preProcessedDataSets = renderableChartSeries.Select(x => x.PreProcessedDataSet);
 
                 (chartStartBin, chartEndBin) =
                     ChartLogic.GetBinRangeToPlotForGaplessRange(
@@ -284,7 +322,7 @@ public sealed class ChartDataBuilder : IChartDataBuilder
 
                 chartBins = BinHelpers.EnumerateBinsInRange(chartStartBin, chartEndBin).ToArray();
 
-                startYears = GetStartYears(chartSeriesWithData);
+                startYears = GetStartYears(renderableChartSeries);
 
                 break;
 
@@ -301,7 +339,7 @@ public sealed class ChartDataBuilder : IChartDataBuilder
                 throw new NotImplementedException($"binGranularity {binGranularity}");
         }
 
-        foreach (var cs in chartSeriesWithData)
+        foreach (var cs in renderableChartSeries)
         {
             l.LogInformation("constructing ProcessedDataSet");
 
@@ -333,7 +371,7 @@ public sealed class ChartDataBuilder : IChartDataBuilder
         // later allow users to say "just give me month-ignoring-year, but only for months after 4 and before 7",
         // for example.
         var binIdsToPlot = new HashSet<string>(chartBins.Select(x => x.Id));
-        foreach (var cswd in chartSeriesWithData)
+        foreach (var cswd in renderableChartSeries)
         {
             cswd.ProcessedDataSet!.DataRecords = [.. cswd.ProcessedDataSet.DataRecords.Where(x => binIdsToPlot.Contains(x.BinId!))];
         }
@@ -342,7 +380,8 @@ public sealed class ChartDataBuilder : IChartDataBuilder
 
         return new ChartDataBuildResult
         {
-            SeriesWithData = chartSeriesWithData,
+            SeriesWithData = renderableChartSeries,
+            NonRenderedSeriesWithData = [.. chartSeriesWithData.Except(renderableChartSeries)],
             ChartBins = chartBins,
             ChartStartBin = chartStartBin,
             ChartEndBin = chartEndBin,

--- a/ClimateExplorer.Web.Client/UiModel/ChartSeriesDataStatus.cs
+++ b/ClimateExplorer.Web.Client/UiModel/ChartSeriesDataStatus.cs
@@ -1,0 +1,10 @@
+namespace ClimateExplorer.Web.UiModel;
+
+public enum ChartSeriesDataStatus
+{
+    Rendered,
+    NoRawData,
+    NoChartableDataAfterCompletenessFiltering,
+    NoChartableDataAfterSmoothing,
+    FallbackToUnsmoothedData,
+}

--- a/ClimateExplorer.Web.Client/UiModel/SeriesWithData.cs
+++ b/ClimateExplorer.Web.Client/UiModel/SeriesWithData.cs
@@ -8,4 +8,5 @@ public sealed record SeriesWithData
     public required DataSet SourceDataSet { get; set; }
     public DataSet? PreProcessedDataSet { get; set; }
     public DataSet? ProcessedDataSet { get; set; }
+    public ChartSeriesDataStatus DataStatus { get; set; } = ChartSeriesDataStatus.Rendered;
 }

--- a/docs/design/2026-06-22-01-chart-series-chartability-investigation.md
+++ b/docs/design/2026-06-22-01-chart-series-chartability-investigation.md
@@ -1,0 +1,83 @@
+# Chart series chartability investigation
+
+## Summary
+
+Antananarivo Ivato, Madagascar is registered as having both temperature and precipitation data. Temperature produces chartable values, but precipitation can produce zero chartable yearly datapoints after the chart aggregation and completeness threshold are applied.
+
+Before this fix, one requested series with no chartable values could prevent the whole chart result from being prepared. The location page then showed the full no-data state, "No chart data is available for the selected location and series.", and the page displayed the generic snackbar, "Failed to create the chart with the current settings."
+
+The chart pipeline should treat this as a per-series chartability result. The requested chart state remains unchanged, renderable series are plotted, and non-renderable series are reported with a warning.
+
+## Current chart availability model
+
+Chart series availability starts in `ChartState.Series`. The chart builder filters this list to `DataAvailable` series before it calls the API. For each usable `ChartSeriesDefinition`, `ChartDataBuilder.RetrieveDataSets` calls `IDataService.PostDataSet` with the selected bin granularity, aggregation functions, value option, source specifications, grouping threshold, grouping days, transformation, year filter, and minimum data resolution.
+
+That availability check only says the data type is registered and usable for the location or source. It does not prove that the current processing settings will produce chartable values.
+
+## Completeness filtering
+
+Completeness filtering is applied in the API data preparation path. `DataSetBuilder.BuildDataSetFromDataRecords` bins raw records, applies `BinRejector.ApplyBinRejectionRules`, aggregates surviving bins, and then calculates final bin values. If all resulting chartable datapoints are null, `DataSetBuilder.BuildDataSet` returns an empty datapoint array.
+
+`DataSetEndpoints.PostDataSets` converts those datapoints into a `DataSet.DataRecords` list. Therefore, a returned `DataSet` can be valid and registered for the selected data type while having no chartable `DataRecords`.
+
+## Empty series behavior before the fix
+
+`ChartDataBuilder.BuildProcessedDataSets` previously passed every requested series into the gapless range calculation. For linear granularities, `ChartLogic.GetBinRangeToPlotForGaplessRange` asks each preprocessed dataset for its first and last record with a value. `DataSetExtensionMethods.GetFirstDataRecordWithValueInDataSet` throws when a dataset has no valued records.
+
+That means a precipitation dataset with zero chartable records could stop the whole build before temperature was rendered. The parent page caught the exception as a generic build failure, set `ChartDataLoadingErrored`, produced an empty `ChartDataBuildResult`, and showed the generic failure snackbar.
+
+## Antananarivo Ivato precipitation
+
+Antananarivo Ivato precipitation is available at the data definition/location level, so the default location chart includes precipitation on non-mobile displays. The raw data can exist, but after grouping and completeness checks, no precipitation years meet the configured threshold. The API therefore returns an empty chartable dataset for precipitation. That is not the same as the precipitation data type being unavailable.
+
+## Distinctions in the pipeline
+
+Before this fix, the chart path only partially distinguished these states:
+
+- Data type unavailable: handled before build by `ChartSeriesDefinition.DataAvailable`.
+- Raw data unavailable: not represented as a structured chart result in the web chart builder.
+- Raw data available but incomplete: collapsed into an empty chartable dataset after API preparation.
+- Completeness filtering removed all points: previously surfaced indirectly as a build failure or no-data chart.
+- Smoothing removed too many points: handled explicitly by falling back to unsmoothed data and returning a warning snackbar message.
+
+The new result model adds `ChartSeriesDataStatus` and `ChartDataBuildResult.NonRenderedSeriesWithData`, so the builder can report that a requested series had no chartable data after completeness filtering without removing it from chart state.
+
+## Partial rendering
+
+The chart rendering path can render partial results as long as `ChartDataBuildResult.SeriesWithData` contains only renderable series and `HasRenderableData` is true. The fix makes `SeriesWithData` the render list and `NonRenderedSeriesWithData` the skipped list. `ChartView` already renders whatever `SeriesWithData` it receives, so no state removal is required in the component.
+
+The selected/configured series remain in `ChartState.Series`. When the user changes to another location, the normal location substitution and rebuild flow runs again. If the previously skipped data type produces chartable data for the next location, it appears again automatically.
+
+## Snackbar layer
+
+Existing moving-average warnings are emitted by `ChartDataBuilder` as result messages and displayed by `ChartablePage`. This is the right layer for this case too: the builder knows why a requested series could not be rendered, while the page owns presentation via the snackbar stack.
+
+The new warning is generic by data type:
+
+`The completeness threshold removed all [data-type] observations for [location-name].`
+
+`There is not enough complete [data-type] data to chart this series.`
+
+## Root cause
+
+The root cause was that chart series availability and chart series chartability were treated as the same thing. A registered data type was assumed to produce at least one valued chart datapoint. When completeness filtering invalidated every datapoint for one series, the linear-range calculation still tried to include that empty series and the whole chart build failed.
+
+## Implemented solution
+
+The builder now:
+
+- Detects requested series whose API-returned dataset has no finite values.
+- Marks those series as `NoChartableDataAfterCompletenessFiltering`.
+- Adds a warning message for each skipped series.
+- Builds chart bins and processed datasets from renderable series only.
+- Returns renderable series in `SeriesWithData` and skipped series in `NonRenderedSeriesWithData`.
+- Leaves `ChartState.Series` untouched, so navigation and location changes do not create stale chart configuration.
+- Preserves the existing moving-average fallback path and marks it as `FallbackToUnsmoothedData`.
+
+The chart shows the full no-data state only when no requested series has chartable datapoints.
+
+## Risks and follow-ups
+
+This fix infers "no chartable data after completeness filtering" from an empty API-returned chartable dataset. That matches the current API behavior for all-bins-rejected results, but the pipeline still does not fully distinguish no raw data from raw data filtered out unless raw records are explicitly requested or the API returns structured status metadata.
+
+Future improvement: move the status model deeper into the API response so `NoRawData`, `NoChartableDataAfterCompletenessFiltering`, and other no-output causes are first-class rather than inferred by the web chart builder.


### PR DESCRIPTION
Previously, any series with no chartable data after completeness filtering caused the entire chart build to fail. Now, the pipeline distinguishes between renderable and non-renderable series using a new `ChartSeriesDataStatus` enum and `NonRenderedSeriesWithData` in `ChartDataBuildResult`. Skipped series generate warning messages, while others are rendered if possible. Chart state remains unchanged, and new tests and helpers cover these scenarios for improved robustness and user feedback.