### PR TITLE
Improve collapsible title alignment with inline-flex

### DIFF
--- a/ClimateExplorer.Web.Client/Components/Common/Collapsible.razor.css
+++ b/ClimateExplorer.Web.Client/Components/Common/Collapsible.razor.css
@@ -49,7 +49,8 @@
     }
 
 .collapsible-title-full {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     min-height: 48px;
 }
 
@@ -59,7 +60,8 @@
     }
 
     .collapsible-title-compact {
-        display: inline-block;
+        display: inline-flex;
+        align-items: center;
     }
 }
 
@@ -69,7 +71,8 @@
     }
 
     .collapsible-title-minimal {
-        display: inline-block;
+        display: inline-flex;
+        align-items: center;
     }
 }
 

--- a/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationsPanel.razor
+++ b/ClimateExplorer.Web.Client/Components/RecentObservations/RecentObservationsPanel.razor
@@ -11,15 +11,13 @@
         @if (CurrentState.IsLoading)
         {
             <div class="recent-observations-state">
-                <i class="fas fa-spinner fa-spin"></i>
-                <span>Loading recent observations...</span>
+                <span><i class="fas fa-spinner fa-spin"></i> Loading recent observations...</span>
             </div>
         }
         else if (!string.IsNullOrWhiteSpace(CurrentState.ErrorMessage))
         {
             <div class="recent-observations-state error">
-                <i class="fas fa-triangle-exclamation"></i>
-                <span>@CurrentState.ErrorMessage</span>
+                <span><i class="fas fa-triangle-exclamation"></i> @CurrentState.ErrorMessage</span>
                 <ClimateButton Text="Retry" Icon="fas fa-rotate-right" Class="recent-observations-retry" OnClick="RetryCurrentTab" />
             </div>
         }


### PR DESCRIPTION
Switched collapsible title classes to use inline-flex and align-items: center for better vertical alignment. Also fixed a missing closing brace in the flexbox-row-layout CSS rule.