### PR TITLE
Broaden workflow triggers to all subdirectories

### DIFF
--- a/.github/workflows/master_api-climateexplorer.yml
+++ b/.github/workflows/master_api-climateexplorer.yml
@@ -8,10 +8,10 @@ on:
     branches:
       - master
     paths:
-      - ClimateExplorer.Core/*
-      - ClimateExplorer.SourceData/*
-      - ClimateExplorer.DataPipeline/*
-      - ClimateExplorer.WebApi/*
+      - ClimateExplorer.Core/**
+      - ClimateExplorer.SourceData/**
+      - ClimateExplorer.DataPipeline/**
+      - ClimateExplorer.WebApi/**
 
   workflow_dispatch:
 


### PR DESCRIPTION
Updated workflow trigger paths to use `**` instead of `*`, ensuring workflows run on changes to files in all nested subdirectories under `ClimateExplorer.Core`, `ClimateExplorer.SourceData`, `ClimateExplorer.DataPipeline`, and `ClimateExplorer.WebApi`. This makes workflow triggers more comprehensive and reliable.