### PR TITLE
Add "Temperature + trend" preset with 50yr projections

### DIFF
--- a/ClimateExplorer.Web.Client/UiModel/SuggestedPresetLists.LocationBasedMobile.cs
+++ b/ClimateExplorer.Web.Client/UiModel/SuggestedPresetLists.LocationBasedMobile.cs
@@ -3,6 +3,7 @@ namespace ClimateExplorer.Web.UiModel;
 using ClimateExplorer.Core.DataPreparation;
 using ClimateExplorer.Core.Model;
 using ClimateExplorer.Core.ViewModel;
+using ClimateExplorer.Web.Client.UiModel.Trends;
 using static ClimateExplorer.Core.Enums;
 
 public static partial class SuggestedPresetLists
@@ -49,6 +50,39 @@ public static partial class SuggestedPresetLists
                 ],
                 Variants =
                 [
+                    new()
+                    {
+                        Title = "Temperature + trend",
+                        Description = "Smoothed yearly average temperature with 50-year predictions",
+                        ChartSeriesList =
+                        [
+                            new ChartSeriesDefinition()
+                            {
+                                SeriesDerivationType = SeriesDerivationTypes.ReturnSingleSeries,
+                                SourceSeriesSpecifications = SourceSeriesSpecification.BuildArray(location, temperature!),
+                                Aggregation = SeriesAggregationOptions.Mean,
+                                BinGranularity = BinGranularities.ByYear,
+                                Smoothing = SeriesSmoothingOptions.MovingAverage,
+                                SmoothingWindow = 10,
+                                Value = SeriesValueOptions.Value,
+                                Trends =
+                                [
+                                    new ChartSeriesTrendRequest
+                                    {
+                                        RegressionType = TrendRegressionType.Linear,
+                                        TrendPeriod = TrendWindow.Full,
+                                        TrendPredictionYears = 50,
+                                    },
+                                    new ChartSeriesTrendRequest
+                                    {
+                                        RegressionType = TrendRegressionType.Quadratic,
+                                        TrendPeriod = TrendWindow.Full,
+                                        TrendPredictionYears = 50,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
                     new()
                     {
                         Title = "Temperature + precipitation",


### PR DESCRIPTION
Added a new "Temperature + trend" variant to LocationBasedPresetsMobile in SuggestedPresetLists.LocationBasedMobile.cs. This preset includes a chart series for smoothed yearly average temperature and adds 50-year linear and quadratic trend projections using ChartSeriesTrendRequest objects. Smoothing uses moving average and yearly bin granularity.